### PR TITLE
Implement PooledBeat.Tick

### DIFF
--- a/Yam.Core.Test/Rhythm/Services/BeatPooler/PooledBeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Services/BeatPooler/PooledBeatTest.cs
@@ -1,0 +1,64 @@
+using System.Numerics;
+using JetBrains.Annotations;
+using Moq;
+using Yam.Core.Rhythm.Services.BeatPooler;
+using Yam.Core.Test.Utils;
+
+namespace Yam.Core.Test.Rhythm.Services.BeatPooler;
+
+[TestSubject(typeof(PooledBeat))]
+public class PooledBeatTest
+{
+	public class Tick
+	{
+		[Fact]
+		public void SimulateBeatLifecycle()
+		{
+			var host = new Mock<IPooledBeatHost>();
+			Vector2 currentPosition = Vector2.Zero;
+			host.Setup(h => h.SetPosition(It.IsAny<Vector2>()))
+				.Callback((Vector2 v) => currentPosition = v);
+			var pooledBeat = new PooledBeat(host.Object);
+
+			pooledBeat.Tick();
+			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Never);
+
+			var resource = new Mock<IPooledBeatResource>();
+			resource.Setup(r => r.GetSpawningPoint())
+				.Returns(Vector2.One);
+			resource.Setup(r => r.GetTriggerPoint())
+				.Returns(Vector2.One * 10f);
+			resource.Setup(r => r.GetDestructionPoint())
+				.Returns(Vector2.One * 15f);
+
+			var pooler = new Mock<Core.Rhythm.Servers.BeatPooler>(resource.Object);
+			pooledBeat.Initialize(pooler.Object, resource.Object);
+
+			pooledBeat.Tick();
+			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Never);
+
+			// 1.2f is preempt time so at time 0, it should be around the spawning point
+			resource.Setup(r => r.GetPlaybackPosition())
+				.Returns(0);
+			var b = TestingUtils.NewBeatState(timing: 1.2f);
+			pooledBeat.SetActive(b);
+
+			pooledBeat.Tick();
+			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Once);
+			Assert.Equal(Vector2.One, currentPosition);
+
+			// mid point between spawning point and trigger point
+			resource.Setup(r => r.GetPlaybackPosition())
+				.Returns(0.6f);
+			pooledBeat.Tick();
+			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(2));
+			Assert.Equal(Vector2.One * (11f / 2f), currentPosition);
+
+			resource.Setup(r => r.GetPlaybackPosition())
+				.Returns(1.2f);
+			pooledBeat.Tick();
+			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(3));
+			Assert.Equal(Vector2.One * 10f, currentPosition);
+		}
+	}
+}

--- a/Yam.Core.Test/Rhythm/Services/BeatPooler/PooledBeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Services/BeatPooler/PooledBeatTest.cs
@@ -36,40 +36,51 @@ public class PooledBeatTest
 			var pooler = new Mock<Core.Rhythm.Servers.BeatPooler>(resource.Object);
 			pooledBeat.Initialize(pooler.Object, resource.Object);
 
-			pooledBeat.Tick();
-			host.Verify(h => h.Deactivate(), Times.Once);
-			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Never);
+			var setPositionCount = 0;
+			var deactivateCount = 1;
 
-			// 1.2f is preempt time so at time 0, it should be around the spawning point
-			resource.Setup(r => r.GetPlaybackPosition())
-				.Returns(0);
-			var b = TestingUtils.NewBeatState(timing: 1.2f);
-			pooledBeat.SetActive(b);
+			for (int i = 0; i < 2; i++) // we want to make sure the pooled beat works being reused
+			{
+				pooledBeat.Tick();
+				host.Verify(h => h.Deactivate(), Times.Exactly(deactivateCount));
+				host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(setPositionCount));
 
-			pooledBeat.Tick();
-			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Once);
-			Assert.Equal(Vector2.One, currentPosition);
+				// 1.2f is preempt time so at time 0, it should be around the spawning point
+				resource.Setup(r => r.GetPlaybackPosition())
+					.Returns(0);
+				var b = TestingUtils.NewBeatState(timing: 1.2f);
+				pooledBeat.SetActive(b);
 
-			// mid point between spawning point and trigger point
-			resource.Setup(r => r.GetPlaybackPosition())
-				.Returns(0.6f);
-			pooledBeat.Tick();
-			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(2));
-			Assert.Equal(Vector2.One * (11f / 2f), currentPosition);
+				pooledBeat.Tick();
+				setPositionCount++;
+				host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(setPositionCount));
+				Assert.Equal(Vector2.One, currentPosition);
 
-			resource.Setup(r => r.GetPlaybackPosition())
-				.Returns(1.2f);
-			pooledBeat.Tick();
-			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(3));
-			host.Verify(h => h.Deactivate(), Times.Once);
-			Assert.Equal(Vector2.One * 10f, currentPosition);
+				// mid point between spawning point and trigger point
+				resource.Setup(r => r.GetPlaybackPosition())
+					.Returns(0.6f);
+				pooledBeat.Tick();
+				setPositionCount++;
+				host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(setPositionCount));
+				Assert.Equal(Vector2.One * (11f / 2f), currentPosition);
 
-			resource.Setup(r => r.GetPlaybackPosition())
-				.Returns(2.4f);
-			pooledBeat.Tick();
-			host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(4));
-			host.Verify(h => h.Deactivate(), Times.Exactly(2));
-			Assert.True(currentPosition.X > 15f);
+				resource.Setup(r => r.GetPlaybackPosition())
+					.Returns(1.2f);
+				pooledBeat.Tick();
+				setPositionCount++;
+				host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(setPositionCount));
+				host.Verify(h => h.Deactivate(), Times.Exactly(deactivateCount));
+				Assert.Equal(Vector2.One * 10f, currentPosition);
+
+				resource.Setup(r => r.GetPlaybackPosition())
+					.Returns(2.4f);
+				pooledBeat.Tick();
+				setPositionCount++;
+				host.Verify(h => h.SetPosition(It.IsAny<Vector2>()), Times.Exactly(setPositionCount));
+				deactivateCount++;
+				host.Verify(h => h.Deactivate(), Times.Exactly(deactivateCount));
+				Assert.True(currentPosition.X > 15f);
+			}
 		}
 	}
 }

--- a/Yam.Core.Test/Utils/TestingUtils.cs
+++ b/Yam.Core.Test/Utils/TestingUtils.cs
@@ -5,11 +5,14 @@ namespace Yam.Core.Test.Utils;
 
 public static class TestingUtils
 {
-	internal static BeatState NewBeatState()
+	internal static BeatState NewBeatState(float timing = 0f)
 	{
 		return new BeatState(
 			timingSection: new TimingSection(),
-			beatModel: new BeatModel()
+			beatModel: new BeatModel
+			{
+				Timing = timing
+			}
 		);
 	}
 }

--- a/Yam.Core/Rhythm/Models/Base/TimingSection.cs
+++ b/Yam.Core/Rhythm/Models/Base/TimingSection.cs
@@ -2,9 +2,9 @@
 
 public record TimingSection
 {
-    public float Timing { get; set; }
-    public float BPM { get; set; }
-    public float BeatLength { get; set; }
-    public int BeatsPerMeter { get; set; }
-    public float ApproachRate { get; set; }
+	public float Timing { get; set; }
+	public float BPM { get; set; }
+	public float BeatLength { get; set; }
+	public int BeatsPerMeter { get; set; }
+	public float ApproachRate { get; set; } = 5f;
 }

--- a/Yam.Core/Rhythm/Models/Wrappers/BeatState.cs
+++ b/Yam.Core/Rhythm/Models/Wrappers/BeatState.cs
@@ -13,7 +13,9 @@ internal class BeatState
 	internal BeatModel Beat { get; set; }
 	private TimingSection TimingSection { get; set; }
 	internal float PreemptTime { get; set; }
+	internal float PreemptDuration { get; }
 	internal VisualizationState VisualizationState { get; set; }
+	public float Timing => Beat.Timing;
 
 	internal BeatState(BeatModel beatModel, TimingSection timingSection)
 	{
@@ -21,17 +23,17 @@ internal class BeatState
 		TimingSection = timingSection;
 
 		// calculation from osu: https://osu.ppy.sh/wiki/en/Beatmap/Approach_rate
-		var preemptDuration = 0f;
+		PreemptDuration = 0f;
 		if (TimingSection.ApproachRate > 5)
 		{
-			preemptDuration = 1.2f - .75f * (TimingSection.ApproachRate - 5) / 5;
+			PreemptDuration = 1.2f - .75f * (TimingSection.ApproachRate - 5) / 5;
 		}
 		else
 		{
-			preemptDuration = 1.2f + .75f * (5 - TimingSection.ApproachRate) / 5;
+			PreemptDuration = 1.2f + .75f * (5 - TimingSection.ApproachRate) / 5;
 		}
 
-		PreemptTime = Beat.Timing - preemptDuration;
+		PreemptTime = Beat.Timing - PreemptDuration;
 	}
 
 

--- a/Yam.Core/Rhythm/Models/Wrappers/ChartState.cs
+++ b/Yam.Core/Rhythm/Models/Wrappers/ChartState.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Yam.Core.Rhythm.Models.Base;
+using Yam.Core.Rhythm.Services;
 
 namespace Yam.Core.Rhythm.Models.Wrappers;
 

--- a/Yam.Core/Rhythm/Servers/BeatPooler.cs
+++ b/Yam.Core/Rhythm/Servers/BeatPooler.cs
@@ -35,7 +35,7 @@ internal class BeatPooler
 		else
 		{
 			newPooledBeat = _beatResource.RequestResource();
-			newPooledBeat.Initialize(this);
+			newPooledBeat.Initialize(this, _beatResource);
 		}
 
 		_inUse.Add(newPooledBeat);

--- a/Yam.Core/Rhythm/Services/BeatPooler/IPooledBeatHost.cs
+++ b/Yam.Core/Rhythm/Services/BeatPooler/IPooledBeatHost.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace Yam.Core.Rhythm.Services.BeatPooler;
 
 public interface IPooledBeatHost
@@ -5,4 +7,5 @@ public interface IPooledBeatHost
 	void Deactivate();
 	void Activate();
 	void DestroyResource();
+	void SetPosition(Vector2 vector2);
 }

--- a/Yam.Core/Rhythm/Services/BeatPooler/IPooledBeatResource.cs
+++ b/Yam.Core/Rhythm/Services/BeatPooler/IPooledBeatResource.cs
@@ -1,6 +1,11 @@
+using System.Numerics;
+
 namespace Yam.Core.Rhythm.Services.BeatPooler;
 
-public interface IPooledBeatResource
+public interface IPooledBeatResource : IAudioPosition
 {
 	public PooledBeat RequestResource();
+	public Vector2 GetSpawningPoint();
+	public Vector2 GetTriggerPoint();
+	public Vector2 GetDestructionPoint();
 }

--- a/Yam.Core/Rhythm/Services/BeatPooler/PooledBeat.cs
+++ b/Yam.Core/Rhythm/Services/BeatPooler/PooledBeat.cs
@@ -24,6 +24,7 @@ public class PooledBeat
 	private Vector2 _destructionPoint;
 	private Vector2 _triggerPoint;
 	private Vector2 _spawningPoint;
+	private bool _isLtr;
 
 	public PooledBeat(IPooledBeatHost host)
 	{
@@ -36,6 +37,9 @@ public class PooledBeat
 		_spawningPoint = _hostResource.GetSpawningPoint();
 		_triggerPoint = _hostResource.GetTriggerPoint();
 		_destructionPoint = _hostResource.GetDestructionPoint();
+
+		// todo: possibly support up and down points
+		_isLtr = _triggerPoint.X < _destructionPoint.X;
 
 		// precalculating linear interpolation
 		// v = v_spawning + [(v_trigger - v_spawning)/(timing - preempt_time)]*(current_time - preeempt_time)
@@ -62,6 +66,12 @@ public class PooledBeat
 		var v = _spawningPoint + ((_triggerPoint - _spawningPoint) / _beat.PreemptDuration)
 			* (_hostResource.GetPlaybackPosition() - _beat.PreemptTime);
 		_host.SetPosition(v);
+
+		if ((_isLtr && v.X > _destructionPoint.X)
+		    || (!_isLtr && v.X < _destructionPoint.X))
+		{
+			Deactivate();
+		}
 	}
 
 	public void Deactivate()

--- a/Yam.Core/Rhythm/Services/BeatPooler/PooledBeat.cs
+++ b/Yam.Core/Rhythm/Services/BeatPooler/PooledBeat.cs
@@ -25,6 +25,7 @@ public class PooledBeat
 	private Vector2 _triggerPoint;
 	private Vector2 _spawningPoint;
 	private bool _isLtr;
+	private Vector2 _precalculatedLerp;
 
 	public PooledBeat(IPooledBeatHost host)
 	{
@@ -43,7 +44,8 @@ public class PooledBeat
 
 		// precalculating linear interpolation
 		// v = v_spawning + [(v_trigger - v_spawning)/(timing - preempt_time)]*(current_time - preeempt_time)
-		// todo: let's first test it out live
+		// we can precalculate everything inside []
+		_precalculatedLerp = (_triggerPoint - _spawningPoint) / _beat.PreemptDuration;
 
 		_host.Activate();
 	}
@@ -63,7 +65,8 @@ public class PooledBeat
 		}
 
 		// linear interpolation
-		var v = _spawningPoint + ((_triggerPoint - _spawningPoint) / _beat.PreemptDuration)
+		// see SetActive to learn the full equation
+		var v = _spawningPoint + _precalculatedLerp
 			* (_hostResource.GetPlaybackPosition() - _beat.PreemptTime);
 		_host.SetPosition(v);
 

--- a/Yam.Core/Rhythm/Services/IAudioPosition.cs
+++ b/Yam.Core/Rhythm/Services/IAudioPosition.cs
@@ -1,4 +1,4 @@
-﻿namespace Yam.Core.Rhythm.Models.Base;
+﻿namespace Yam.Core.Rhythm.Services;
 
 public interface IAudioPosition
 {

--- a/Yam.Godot/Scenes/Rhythm/rhythm_editor.tscn
+++ b/Yam.Godot/Scenes/Rhythm/rhythm_editor.tscn
@@ -1,13 +1,29 @@
-[gd_scene load_steps=4 format=3 uid="uid://bt1qe76771afk"]
+[gd_scene load_steps=5 format=3 uid="uid://bt1qe76771afk"]
 
 [ext_resource type="Script" path="res://Scripts/Rhythm/RhythmEditorMain.cs" id="1_af2kv"]
 [ext_resource type="JSON" path="res://Scenes/Rhythm/Songs/sunleth_waterscape/chart_meta.json" id="2_yy6yc"]
 [ext_resource type="PackedScene" uid="uid://bh8con8llm0d7" path="res://Scenes/Rhythm/pooled_beat.tscn" id="3_ev2oq"]
+[ext_resource type="Texture2D" uid="uid://corpi772is0cb" path="res://Assets/Placeholder/white_square.png" id="4_skhgu"]
 
-[node name="RhythmEditor" type="Node2D" node_paths=PackedStringArray("AudioStreamPlayer")]
+[node name="RhythmEditor" type="Node2D" node_paths=PackedStringArray("AudioStreamPlayer", "SpawningPoint", "TriggerPoint", "DestructionPoint")]
 script = ExtResource("1_af2kv")
 ChartResource = ExtResource("2_yy6yc")
 AudioStreamPlayer = NodePath("AudioStreamPlayer")
 GodotPooledBeat = ExtResource("3_ev2oq")
+SpawningPoint = NodePath("SpawningPoint")
+TriggerPoint = NodePath("TriggerPoint")
+DestructionPoint = NodePath("DestructionPoint")
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+
+[node name="TriggerPoint" type="Sprite2D" parent="."]
+position = Vector2(920, 325)
+texture = ExtResource("4_skhgu")
+
+[node name="SpawningPoint" type="Sprite2D" parent="."]
+position = Vector2(-210, 325)
+texture = ExtResource("4_skhgu")
+
+[node name="DestructionPoint" type="Sprite2D" parent="."]
+position = Vector2(1312, 325)
+texture = ExtResource("4_skhgu")

--- a/Yam.Godot/Scripts/Rhythm/GodotPooledBeat.cs
+++ b/Yam.Godot/Scripts/Rhythm/GodotPooledBeat.cs
@@ -1,5 +1,6 @@
 using Godot;
 using Yam.Core.Rhythm.Services.BeatPooler;
+using SystemVector2 = System.Numerics.Vector2;
 
 namespace Yam.Godot.Scripts.Rhythm;
 
@@ -19,18 +20,22 @@ public partial class GodotPooledBeat : Node2D, IPooledBeatHost
 
 	public void Deactivate()
 	{
-		// todo: put it in a far away place no one can see and set visibility to invisible
-		throw new System.NotImplementedException();
+		Visible = false;
+		Position = new Vector2(-100, -100);
 	}
 
 	public void Activate()
 	{
-		// todo: do the opposite of deactivate
-		throw new System.NotImplementedException();
+		Visible = true;
 	}
 
 	public void DestroyResource()
 	{
 		QueueFree();
+	}
+
+	public void SetPosition(SystemVector2 vector2)
+	{
+		Position = new Vector2(vector2.X, vector2.Y);
 	}
 }

--- a/Yam.Godot/Scripts/Rhythm/RhythmEditorMain.cs
+++ b/Yam.Godot/Scripts/Rhythm/RhythmEditorMain.cs
@@ -6,6 +6,7 @@ using Yam.Core.Rhythm.Clients;
 using Yam.Core.Rhythm.Models.Base;
 using Yam.Core.Rhythm.Services;
 using Yam.Core.Rhythm.Services.BeatPooler;
+using Vector2 = System.Numerics.Vector2;
 
 namespace Yam.Godot.Scripts.Rhythm;
 
@@ -14,14 +15,27 @@ public partial class RhythmEditorMain : Node2D, IRhythmGameHost, IPooledBeatReso
 	[Export] public Resource ChartResource { get; set; }
 	[Export] public AudioStreamPlayer AudioStreamPlayer { get; set; }
 	[Export] public PackedScene GodotPooledBeat { get; set; }
+	[Export] public Node2D SpawningPoint { get; set; }
+	[Export] public Node2D TriggerPoint { get; set; }
+	[Export] public Node2D DestructionPoint { get; set; }
 
 	private IChartEditor _editor;
 	private List<IGameListeners> _listeners = new();
 	private float _currentAudioTime;
+	private Vector2 _spawningPosition;
+	private Vector2 _triggerPosition;
+	private Vector2 _destructionPosition;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
+		var spawningGVector = SpawningPoint.Position;
+		_spawningPosition = new Vector2(spawningGVector.X, spawningGVector.Y);
+		var triggerGVector = TriggerPoint.Position;
+		_triggerPosition = new Vector2(triggerGVector.X, triggerGVector.Y);
+		var destructionGVector = DestructionPoint.Position;
+		_destructionPosition = new Vector2(destructionGVector.X, destructionGVector.Y);
+
 		ParseAndPlayChart();
 	}
 
@@ -79,5 +93,20 @@ public partial class RhythmEditorMain : Node2D, IRhythmGameHost, IPooledBeatReso
 		var pooledBeat = GodotPooledBeat.Instantiate<GodotPooledBeat>();
 		AddChild(pooledBeat);
 		return pooledBeat.PooledBeat;
+	}
+
+	public Vector2 GetSpawningPoint()
+	{
+		return _spawningPosition;
+	}
+
+	public Vector2 GetTriggerPoint()
+	{
+		return _triggerPosition;
+	}
+
+	public Vector2 GetDestructionPoint()
+	{
+		return _destructionPosition;
 	}
 }


### PR DESCRIPTION
# Overview

PooledBeat.Tick is where the individual beat animation and their lifecycle happens

## Screenshot

![pooled_beat](https://github.com/TurnipXenon/Yam/assets/21351900/4c5aa997-523d-418a-b54a-6f84c11691fc)

The host has three points, which are represented as white squares in the screen capture. From left to right, they are the spawning point, trigger point, and destruction point.

The Chart Visualizer requests the BeatPooler for a PooledBeat if the BeatState sees that the current playback position is greater than the beat's pre-empted time.

The PooledBeat, when activated with a BeatState, will linearly interpolate it's location based on the current time. More precisely the formula looks like this:

```
currentPosition = spawnPosition + [(triggerPosition - spawningPosition)/preEmptDuration]*(currentTime - preEmptTime)
```

The PooledBeat also handles deactivating itself once it goes over the destructionPosition. Currently we handle left-to-right movement, but we'll want to support up-to-down movement, since it's a nice QOL and accessibility feature.