### PR TITLE
Refactor to use events instead of polling

### DIFF
--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -60,31 +60,26 @@ public abstract class BeatTest
             });
 
             var rhythmPlayer = new Mock<IRhythmPlayer>();
-            var inputProvider = new Mock<IRhythmInputProvider>();
-
+            var playerInput = new Mock<IRhythmInput>();
+            playerInput.Setup(i => i.GetRhythmActionType()).Returns(RhythmActionType.Singular);
+            
             // start: too far
             rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(beatTime - (Beat.DefaultTooEarlyRadius + Beat.FrameEpsilon));
-            var tooFar = beat.SimulateInput(rhythmPlayer.Object, inputProvider.Object);
+            var tooFar = beat.SimulateInput(rhythmPlayer.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Idle, tooFar);
 
             // within range but no inputs yet
             rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(beatTime - Beat.DefaultOkRadius);
-            inputProvider.Setup(i => i.GetSingularInputList()).Returns(new List<KeyboardSingularInput>());
-            var noInput = beat.SimulateInput(rhythmPlayer.Object, inputProvider.Object);
+            var noInput = beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput);
             Assert.Equal(BeatInputResult.Anticipating, noInput);
-
+            
             // within range of excellent with input
             rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(beatTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
-            inputProvider.Setup(i => i.GetSingularInputList()).Returns(new List<KeyboardSingularInput>()
-            {
-                new("testCode")
-                // todo: decide the values later as we go
-            });
-            var excellentInput = beat.SimulateInput(rhythmPlayer.Object, inputProvider.Object);
+            var excellentInput = beat.SimulateInput(rhythmPlayer.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Excellent, excellentInput);
-
+            
             // check the beat after it's done
-            Assert.Equal(BeatInputResult.Done, beat.SimulateInput(rhythmPlayer.Object, inputProvider.Object));
+            Assert.Equal(BeatInputResult.Done, beat.SimulateInput(rhythmPlayer.Object, playerInput.Object));
         }
         
         // todo(turnip): no input and miss

--- a/Yam.Core/Common/Logger.cs
+++ b/Yam.Core/Common/Logger.cs
@@ -1,0 +1,6 @@
+namespace Yam.Core.Common;
+
+public class Logger
+{
+    // todo(turnip): access GD.Print when detecting Godot but use Console during test or not in Godot
+}

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -42,7 +42,7 @@ public class BeatChannel : List<Beat>
         return _currentInputIndex >= Count ? null : this[_currentInputIndex];
     }
 
-    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInputProvider inputProvider)
+    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput inputProvider)
     {
         var currentBeat = TryToGetBeatForInput();
         var result = currentBeat?.SimulateInput(rhythmPlayer, inputProvider);

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -65,8 +65,8 @@ public class Chart
         return beats;
     }
 
-    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInputProvider inputProvider)
+    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput input)
     {
-        ChannelList.ForEach(c => c.SimulateBeatInput(rhythmPlayer, inputProvider));
+        ChannelList.ForEach(c => c.SimulateBeatInput(rhythmPlayer, input));
     }
 }

--- a/Yam.Core/Rhythm/Input/IRhythmInput.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInput.cs
@@ -7,20 +7,24 @@ namespace Yam.Core.Rhythm.Input;
 public interface IRhythmInput
 {
     public bool IsValidDirection();
+
     /**
      * True if we want more sensitivity or player is using a mouse or they feel turning it on with a slide pad
      * False if slide pad (default behavior) or button
      */
     public bool IsDirectionSensitive();
+
     public Vector2 GetDirection();
     public string GetInputCode();
-    public Beat? GetClaimingChannel();
+    public IBeat? GetClaimingChannel();
 
     /// <summary>
     /// Returns true if successfully claimed channel. False if another channel claimed this input
     /// </summary>
     /// <returns></returns>
-    public bool ClaimInput(Beat beat);
+    public bool ClaimOnStart(IBeat beat);
 
     public void ReleaseInput();
+    public InputSource GetSource();
+    RhythmActionType GetRhythmActionType();
 }

--- a/Yam.Core/Rhythm/Input/IRhythmInputProvider.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInputProvider.cs
@@ -11,7 +11,7 @@ namespace Yam.Core.Rhythm.Input;
  */
 public interface IRhythmInputProvider
 {
-    public List<KeyboardDirectionInput> GetDirectionInputList();
-    public List<KeyboardSingularInput> GetSingularInputList();
+    public List<ISingularInput> GetDirectionInputList();
+    public List<ISingularInput> GetSingularInputList();
     public void PollInput();
 }

--- a/Yam.Core/Rhythm/Input/ISingularInput.cs
+++ b/Yam.Core/Rhythm/Input/ISingularInput.cs
@@ -1,6 +1,8 @@
+using Yam.Core.Rhythm.Chart;
+
 namespace Yam.Core.Rhythm.Input;
 
-public interface ISingularInput
+public interface ISingularInput: IRhythmInput
 {
     // todo(turnip): now
 }

--- a/Yam.Core/Rhythm/Input/InputSource.cs
+++ b/Yam.Core/Rhythm/Input/InputSource.cs
@@ -1,0 +1,8 @@
+namespace Yam.Core.Rhythm.Input;
+
+public enum InputSource
+{
+    Game, // simulating that one _process game update has passed and ignores inputs
+    Player, // a player did something that's mapped in the input system
+    Unknown, // an input we don't care about, e.g. pressing a random key or gamepad button
+}

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -9,7 +9,7 @@ namespace Yam.Core.Rhythm.Input;
 // note to self: knows the implementation?
 // todo(turnip): create ISingularInput. this is a keyboard implementation
 // todo(turnip): OnStarted, OnHold, OnRelease (document differences)
-public partial class KeyboardSingularInput
+public class KeyboardSingularInput : ISingularInput
 {
     // todo(turnip): see if we can combine them into the details class below
     private IBeat? _claimingBeat;
@@ -53,6 +53,16 @@ public partial class KeyboardSingularInput
     public void ReleaseInput()
     {
         _claimingBeat = null;
+    }
+
+    public InputSource GetSource()
+    {
+        return InputSource.Game;
+    }
+
+    public RhythmActionType GetRhythmActionType()
+    {
+        return RhythmActionType.Singular;
     }
 
     private SingularInputState _singularInputState = SingularInputState.Free;

--- a/Yam.Core/Rhythm/Input/RhythmActionType.cs
+++ b/Yam.Core/Rhythm/Input/RhythmActionType.cs
@@ -1,0 +1,8 @@
+namespace Yam.Core.Rhythm.Input;
+
+public enum RhythmActionType
+{
+    Singular,
+    Directional,
+    Invalid
+}

--- a/Yam.Core/Rhythm/Input/SpecialInput.cs
+++ b/Yam.Core/Rhythm/Input/SpecialInput.cs
@@ -1,0 +1,64 @@
+using System;
+using Godot;
+using Yam.Core.Rhythm.Chart;
+
+namespace Yam.Core.Rhythm.Input;
+
+public class SpecialInput : IRhythmInput
+{
+    // Inspired by the Null Object Pattern
+    public static readonly SpecialInput GameInput = new(InputSource.Game);
+    public static readonly SpecialInput UnknownInput = new(InputSource.Unknown);
+
+    private readonly InputSource _source;
+
+    private SpecialInput(InputSource source)
+    {
+        _source = source;
+    }
+
+    public bool IsValidDirection()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool IsDirectionSensitive()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Vector2 GetDirection()
+    {
+        throw new NotImplementedException();
+    }
+
+    public string GetInputCode()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IBeat? GetClaimingChannel()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool ClaimOnStart(IBeat beat)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ReleaseInput()
+    {
+        throw new NotImplementedException();
+    }
+
+    public InputSource GetSource()
+    {
+        return _source;
+    }
+
+    public RhythmActionType GetRhythmActionType()
+    {
+        return RhythmActionType.Invalid;
+    }
+}

--- a/Yam.Game/Scripts/Rhythm/Input/GodotInputProvider.cs
+++ b/Yam.Game/Scripts/Rhythm/Input/GodotInputProvider.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using Godot;
 using Yam.Core.Rhythm.Input;
@@ -7,26 +8,34 @@ namespace Yam.Game.Scripts.Rhythm.Input;
 
 public class GodotInputProvider : IRhythmInputProvider
 {
+    public const string Keyboard1Up = "keyboard1_up";
+
     // 2 slides + input combo then 6 more solo input combos
     private List<IRhythmInput> _activeInputList = new();
 
     private KeyboardDirectionInput _keyboardDirectionInput = new();
+    private readonly KeyboardSingularInput _keyboardUp = new(Keyboard1Up);
 
-    private List<KeyboardSingularInput> _keyboardSingularInputList = new()
-    {
-        new KeyboardSingularInput("keyboard1_up"),
-        new KeyboardSingularInput("keyboard1_down"),
-        new KeyboardSingularInput("keyboard1_left"),
-        new KeyboardSingularInput("keyboard1_right")
-    };
+    private readonly List<ISingularInput> _keyboardSingularInputList;
 
-    public List<KeyboardDirectionInput> GetDirectionInputList()
+    public GodotInputProvider()
     {
-        // todo(turnip): do something
-        return new ();
+        _keyboardSingularInputList = new List<ISingularInput>
+        {
+            _keyboardUp,
+            new KeyboardSingularInput("keyboard1_down"),
+            new KeyboardSingularInput("keyboard1_left"),
+            new KeyboardSingularInput("keyboard1_right")
+        };
     }
 
-    public List<KeyboardSingularInput> GetSingularInputList()
+    public List<ISingularInput> GetDirectionInputList()
+    {
+        // todo(turnip): do something
+        return _keyboardSingularInputList;
+    }
+
+    public List<ISingularInput> GetSingularInputList()
     {
         // todo: fix
         return _keyboardSingularInputList;
@@ -35,32 +44,51 @@ public class GodotInputProvider : IRhythmInputProvider
     public void PollInput()
     {
         // because it's complex
-        _keyboardDirectionInput.Direction = Vector2.Zero;
-        
-        if (In.IsActionPressed("keyboard1_up"))
-        {
-            _keyboardDirectionInput.Direction = Vector2.Up;
-        }
-        else if (In.IsActionPressed("keyboard1_down"))
-        {
-            _keyboardDirectionInput.Direction = Vector2.Down;
-        }
+        // _keyboardDirectionInput.Direction = Vector2.Zero;
+        //
+        // if (In.IsActionPressed("keyboard1_up"))
+        // {
+        //     _keyboardDirectionInput.Direction = Vector2.Up;
+        // }
+        // else if (In.IsActionPressed("keyboard1_down"))
+        // {
+        //     _keyboardDirectionInput.Direction = Vector2.Down;
+        // }
+        //
+        // if (In.IsActionPressed("keyboard1_left"))
+        // {
+        //     _keyboardDirectionInput.Direction += Vector2.Left;
+        // } else if (In.IsActionPressed("keyboard1_right"))
+        // {
+        //     _keyboardDirectionInput.Direction += Vector2.Right;
+        // }
 
-        if (In.IsActionPressed("keyboard1_left"))
-        {
-            _keyboardDirectionInput.Direction += Vector2.Left;
-        } else if (In.IsActionPressed("keyboard1_right"))
-        {
-            _keyboardDirectionInput.Direction += Vector2.Right;
-        }
+        // if (_keyboardDirectionInput.GetClaimingChannel() != null)
+        // {
+        //     foreach (var code in _keyboardSingularInputList)
+        //     {
+        //         // todo(turnip): 
+        //     }
+        // }
+    }
 
-        if (_keyboardDirectionInput.GetClaimingChannel() != null)
+    public IRhythmInput ProcessEvent(InputEvent @event)
+    {
+        if (@event.IsAction(Keyboard1Up, true))
         {
-            foreach (var code in _keyboardSingularInputList)
+            // todo(turnip): consider difference with just pressed and held state buffer?
+            if (@event.IsActionReleased(Keyboard1Up))
             {
-                // todo(turnip): 
-                
+                _keyboardUp.Release();
             }
+            else
+            {
+                _keyboardUp.Press();
+            }
+
+            return _keyboardUp;
         }
+
+        return SpecialInput.UnknownInput;
     }
 }

--- a/Yam.Game/Scripts/Rhythm/RhythmPlayer.cs
+++ b/Yam.Game/Scripts/Rhythm/RhythmPlayer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using Godot;
 using Yam.Core.Rhythm.Chart;
+using Yam.Core.Rhythm.Input;
 using Yam.Game.Scripts.Rhythm.Game.SingleBeat;
 using Yam.Game.Scripts.Rhythm.Input;
 using ChartModel = Yam.Core.Rhythm.Chart.Chart;
@@ -79,8 +80,9 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
 
         #region input
 
-        _inputProvider.PollInput();
-        _chartModel.SimulateBeatInput(this, _inputProvider);
+        // todo(turnip): move to the unhandled input handler below
+        // _inputProvider.PollInput();
+        _chartModel.SimulateBeatInput(this, SpecialInput.GameInput);
 
         #endregion input
 
@@ -173,5 +175,11 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
         }
 
         return _processedReactionWindow;
+    }
+
+
+    public override void _UnhandledInput(InputEvent @event)
+    {
+        _chartModel.SimulateBeatInput(this, _inputProvider.ProcessEvent(@event));
     }
 }


### PR DESCRIPTION
## What's this change for?

- Using events instead of polling allows for simpler code. Initially, we wanted to poll every frame for all the inputs. Now, we just get an updated input state from the event, and we don't need to update every input states every game frame.
- Beat logic would not need to take the entire abstracted *InputSystem and would just need to take a singular input to analyze.
  - *I put an asterisk on the InputSystem because it has changed purpose constantly. As of now, GodotInputProvider serves as an abstraction of how the input is provided by Godot. We have this so we can allow hooking up an auto player or maybe simulating an in-game player's behavior of playing the game.


## Detailed description

- Move from polling in _Process event to _UnhandledInput event. The original plan was to poll for every input. Now, we just check the input and figure out which input state we need to update.
- Refactor tests for Beat, particularly SimulateSingleBeat, since it used to play around GodotInputProvider.

## Testing
- [x] Updated testing in BeatTest