### PR TITLE
Integrate singular beat input

### DIFF
--- a/Docs/Troubleshooting.md
+++ b/Docs/Troubleshooting.md
@@ -1,0 +1,22 @@
+# Troubleshooting
+
+## Inconclusive: Exit code is -1073741819 (Output is too long. Showing the last 100 lines:
+
+You would usually encounter this as an exit code during unit testing. This is caused by `GD.Print()`. Right now, we don't have any mechanisms to check if the code is running in Godot's editor or run under xUnit. The only way for our logger to detect if you're in either is by setting the `output` property in GameLogger. If it's null, we use `GD.Print`. Otherwise, use xUnit's `ITestOutputHelper`.
+
+```c#
+public abstract class BeatTest
+{
+        public class SimulateSingleBeat
+    {
+        public SimulateSingleBeat(ITestOutputHelper output)
+        {
+            GameLogger.Output = output;
+        }
+        
+        // tests below with function calls that interact with GameLogger
+    }
+}
+```
+
+For example, if you remove the code above in `BeatTest.SimulateSingleBeat`, the error would appear. The code above does what we mentioned previously.

--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -1,5 +1,7 @@
 using JetBrains.Annotations;
 using Moq;
+using Xunit.Abstractions;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 using Yam.Core.Rhythm.Input;
 using Yam.Core.Test.Utility;
@@ -50,6 +52,11 @@ public abstract class BeatTest
 
     public class SimulateSingleBeat
     {
+        public SimulateSingleBeat(ITestOutputHelper output)
+        {
+            GameLogger.Output = output;
+        }
+        
         [Fact]
         public void BeatLifecycle()
         {

--- a/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
@@ -21,7 +21,7 @@ public abstract class KeyboardSingularInputTest
             Assert.Null(input.GetClaimingChannel());
 
             // you can claim a button only on start, for now
-            input.Press();
+            input.Start();
             Assert.Equal(SingularInputState.Started, input.GetState());
             Assert.True(input.ClaimOnStart(beat.Object));
             Assert.Equal(beat.Object, input.GetClaimingChannel());
@@ -48,11 +48,11 @@ public abstract class KeyboardSingularInputTest
             Assert.Null(input.GetClaimingChannel());
 
             // you can claim a button only on start, for now
-            input.Press();
+            input.Start();
             Assert.Equal(SingularInputState.Started, input.GetState());
             
             // you cannot claim a button outside on start
-            input.Press();
+            input.Start();
             Assert.Equal(SingularInputState.Held, input.GetState());
             Assert.False(input.ClaimOnStart(beat.Object));
             Assert.Null(input.GetClaimingChannel());
@@ -69,13 +69,13 @@ public abstract class KeyboardSingularInputTest
             Assert.Null(input.GetClaimingChannel());
 
             // you can claim a button only on start, for now
-            input.Press();
+            input.Start();
             Assert.Equal(SingularInputState.Started, input.GetState());
             Assert.True(input.ClaimOnStart(beat.Object));
             Assert.Equal(beat.Object, input.GetClaimingChannel());
 
             // hold status
-            input.Press();
+            input.Start();
             Assert.Equal(SingularInputState.Held, input.GetState());
             var differentBeat = new Mock<IBeat>();
             Assert.False(input.ClaimOnStart(differentBeat.Object));

--- a/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
@@ -21,7 +21,7 @@ public abstract class KeyboardSingularInputTest
             Assert.Null(input.GetClaimingChannel());
 
             // you can claim a button only on start, for now
-            input.Start();
+            input.Activate();
             Assert.Equal(SingularInputState.Started, input.GetState());
             Assert.True(input.ClaimOnStart(beat.Object));
             Assert.Equal(beat.Object, input.GetClaimingChannel());
@@ -48,11 +48,11 @@ public abstract class KeyboardSingularInputTest
             Assert.Null(input.GetClaimingChannel());
 
             // you can claim a button only on start, for now
-            input.Start();
+            input.Activate();
             Assert.Equal(SingularInputState.Started, input.GetState());
             
             // you cannot claim a button outside on start
-            input.Start();
+            input.Activate();
             Assert.Equal(SingularInputState.Held, input.GetState());
             Assert.False(input.ClaimOnStart(beat.Object));
             Assert.Null(input.GetClaimingChannel());
@@ -69,13 +69,13 @@ public abstract class KeyboardSingularInputTest
             Assert.Null(input.GetClaimingChannel());
 
             // you can claim a button only on start, for now
-            input.Start();
+            input.Activate();
             Assert.Equal(SingularInputState.Started, input.GetState());
             Assert.True(input.ClaimOnStart(beat.Object));
             Assert.Equal(beat.Object, input.GetClaimingChannel());
 
             // hold status
-            input.Start();
+            input.Activate();
             Assert.Equal(SingularInputState.Held, input.GetState());
             var differentBeat = new Mock<IBeat>();
             Assert.False(input.ClaimOnStart(differentBeat.Object));

--- a/Yam.Core/Common/GameLogger.cs
+++ b/Yam.Core/Common/GameLogger.cs
@@ -1,0 +1,36 @@
+using Godot;
+using Xunit.Abstractions;
+
+namespace Yam.Core.Common;
+
+// todo(turnip): improve GameLogger by detecting that we're being run in xUnit
+// and ignore any calls to Godot. Or check if Godot's GD global function specific
+// to Print is available for use
+public static class GameLogger
+{
+    public static ITestOutputHelper? Output;
+
+    public static void Print(params string[] what)
+    {
+        if (Output != null)
+        {
+            Output.WriteLine(what.Join(""));
+        }
+        else
+        {
+            GD.Print(what);
+        }
+    }
+    
+    public static void PrintErr(string what)
+    {
+        if (Output != null)
+        {
+            Output.WriteLine($"Godot.PrintErr: {what}");
+        }
+        else
+        {
+            GD.PrintErr(what);
+        }
+    }
+}

--- a/Yam.Core/Common/GenericPooler.cs
+++ b/Yam.Core/Common/GenericPooler.cs
@@ -29,7 +29,7 @@ public abstract class GenericPooler<TPooledObject, TPooledObjectArgs>
 
         if (newObject == null)
         {
-            GD.PrintErr("Instantiating Pooled Object failed");
+            GameLogger.PrintErr("Instantiating Pooled Object failed");
         }
         else
         {

--- a/Yam.Core/Common/Logger.cs
+++ b/Yam.Core/Common/Logger.cs
@@ -1,6 +1,0 @@
-namespace Yam.Core.Common;
-
-public class Logger
-{
-    // todo(turnip): access GD.Print when detecting Godot but use Console during test or not in Godot
-}

--- a/Yam.Core/Rhythm/Chart/Beat.cs
+++ b/Yam.Core/Rhythm/Chart/Beat.cs
@@ -177,7 +177,7 @@ public class Beat : TimeUCoordVector, IBeat
         if (_state != State.Waiting)
         {
             // todo(turnip): add test for this case
-            GD.PrintErr($"Not expected result: ({Time}, {UCoord})");
+            GameLogger.PrintErr($"Not expected result: ({Time}, {UCoord})");
             return BeatInputResult.Ignore;
         }
 
@@ -190,7 +190,7 @@ public class Beat : TimeUCoordVector, IBeat
         if (currentTime >= okReaction.Range.Y)
         {
             _state = State.Done;
-            GD.Print($"Missed ({Time}, {UCoord})");
+            GameLogger.Print($"Missed ({Time}, {UCoord})");
             return BeatInputResult.Miss;
         }
 
@@ -200,9 +200,8 @@ public class Beat : TimeUCoordVector, IBeat
             return BeatInputResult.Anticipating;
         }
 
-        if (playerInput.GetClaimingChannel() == null)
+        if (playerInput.GetClaimingChannel() == null && playerInput.ClaimOnStart(this))
         {
-            playerInput.ClaimOnStart(this);
             foreach (var reactionWindow in _reactionWindowList.Where(reactionWindow =>
                          reactionWindow.Range.X < currentTime && currentTime < reactionWindow.Range.Y))
             {

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Godot;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Input;
 
 namespace Yam.Core.Rhythm.Chart;
@@ -59,13 +59,13 @@ public class BeatChannel : List<Beat>
             case BeatInputResult.Ok:
             case BeatInputResult.Good:
             case BeatInputResult.Excellent:
-                GD.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord}): {result.ToString()}");
+                GameLogger.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord}): {result.ToString()}");
                 _currentInputIndex++;
                 break;
             case BeatInputResult.Holding:
                 break;
             case BeatInputResult.Ignore:
-                GD.Print($"IGNORE: Finished with ({currentBeat!.Time}, {currentBeat.UCoord})");
+                GameLogger.Print($"IGNORE: Finished with ({currentBeat!.Time}, {currentBeat.UCoord})");
                 _currentInputIndex++;
                 break;
             case null:

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -42,10 +42,10 @@ public class BeatChannel : List<Beat>
         return _currentInputIndex >= Count ? null : this[_currentInputIndex];
     }
 
-    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput inputProvider)
+    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput playerInput)
     {
         var currentBeat = TryToGetBeatForInput();
-        var result = currentBeat?.SimulateInput(rhythmPlayer, inputProvider);
+        var result = currentBeat?.SimulateInput(rhythmPlayer, playerInput);
 
         switch (result)
         {
@@ -59,7 +59,7 @@ public class BeatChannel : List<Beat>
             case BeatInputResult.Ok:
             case BeatInputResult.Good:
             case BeatInputResult.Excellent:
-                GD.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord})");
+                GD.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord}): {result.ToString()}");
                 _currentInputIndex++;
                 break;
             case BeatInputResult.Holding:

--- a/Yam.Core/Rhythm/Chart/BeatEntity.cs
+++ b/Yam.Core/Rhythm/Chart/BeatEntity.cs
@@ -8,6 +8,15 @@ namespace Yam.Core.Rhythm.Chart;
  */
 public class BeatEntity : TimeUCoordVector
 {
+    public BeatEntity()
+    {
+    }
+
+    public BeatEntity(float time)
+    {
+        Time = time;
+    }
+
     public TimeUCoordVector? PIn { get; set; }
     public TimeUCoordVector? POut { get; set; }
     public List<BeatEntity> BeatList { get; set; } = new();

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Input;
 
 namespace Yam.Core.Rhythm.Chart;
@@ -41,7 +42,7 @@ public class Chart
 
             if (!wasAdded)
             {
-                GD.PrintErr($"Beat not added: {beat.Time}");
+                GameLogger.PrintErr($"Beat not added: {beat.Time}");
             }
 
             // todo: take note of this logic

--- a/Yam.Core/Rhythm/Chart/IBeat.cs
+++ b/Yam.Core/Rhythm/Chart/IBeat.cs
@@ -3,4 +3,5 @@ namespace Yam.Core.Rhythm.Chart;
 public interface IBeat
 {
     void InformRelease();
+    void SetVisualizer(IBeatVisualizer visualizer);
 }

--- a/Yam.Core/Rhythm/Chart/IBeatVisualizer.cs
+++ b/Yam.Core/Rhythm/Chart/IBeatVisualizer.cs
@@ -1,0 +1,6 @@
+namespace Yam.Core.Rhythm.Chart;
+
+public interface IBeatVisualizer
+{
+    void InformEndResult(BeatInputResult result);
+}

--- a/Yam.Core/Rhythm/Input/IRhythmInput.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInput.cs
@@ -27,4 +27,6 @@ public interface IRhythmInput
     public void ReleaseInput();
     public InputSource GetSource();
     RhythmActionType GetRhythmActionType();
+    public void Start();
+    public void Release();
 }

--- a/Yam.Core/Rhythm/Input/IRhythmInput.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInput.cs
@@ -27,6 +27,13 @@ public interface IRhythmInput
     public void ReleaseInput();
     public InputSource GetSource();
     RhythmActionType GetRhythmActionType();
-    public void Start();
+    
+    /// <summary>
+    /// Activate is a generic term to indicate that the input's state has become active
+    /// For buttons, this means they've been pressed
+    /// For mouse, this means they've been moved
+    /// For direction pads, this means they've been moved out of Vector2.Zero
+    /// </summary>
+    public void Activate();
     public void Release();
 }

--- a/Yam.Core/Rhythm/Input/IRhythmInputProvider.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInputProvider.cs
@@ -13,5 +13,4 @@ public interface IRhythmInputProvider
 {
     public List<ISingularInput> GetDirectionInputList();
     public List<ISingularInput> GetSingularInputList();
-    public void PollInput();
 }

--- a/Yam.Core/Rhythm/Input/KeyboardDirectionInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardDirectionInput.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using Godot;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 
 namespace Yam.Core.Rhythm.Input;
@@ -28,7 +29,7 @@ public class KeyboardDirectionInput
             return false;
         }
 
-        GD.Print("Input Claimed");
+        GameLogger.Print("Input Claimed");
         _claimingBeat = claimingBeat;
         return true;
     }

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using Godot;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 
 namespace Yam.Core.Rhythm.Input;
@@ -46,12 +47,14 @@ public class KeyboardSingularInput : ISingularInput
             return false;
         }
 
+        GameLogger.Print("Successfully claimed");
         _claimingBeat = claimingBeat;
         return true;
     }
 
     public void ReleaseInput()
     {
+        GameLogger.Print("Released ", _keyCode);
         _claimingBeat = null;
     }
 

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -67,7 +67,7 @@ public class KeyboardSingularInput : ISingularInput
 
     private SingularInputState _singularInputState = SingularInputState.Free;
 
-    public void Start()
+    public void Activate()
     {
         _singularInputState = _singularInputState switch
         {
@@ -84,6 +84,8 @@ public class KeyboardSingularInput : ISingularInput
 
     public void Release()
     {
+        _singularInputState = SingularInputState.Free;
         _claimingBeat?.InformRelease();
+        _claimingBeat = null;
     }
 }

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -67,7 +67,7 @@ public class KeyboardSingularInput : ISingularInput
 
     private SingularInputState _singularInputState = SingularInputState.Free;
 
-    public void Press()
+    public void Start()
     {
         _singularInputState = _singularInputState switch
         {

--- a/Yam.Core/Rhythm/Input/SpecialInput.cs
+++ b/Yam.Core/Rhythm/Input/SpecialInput.cs
@@ -62,7 +62,7 @@ public class SpecialInput : IRhythmInput
         return RhythmActionType.Invalid;
     }
 
-    public void Start()
+    public void Activate()
     {
         throw new NotImplementedException();
     }

--- a/Yam.Core/Rhythm/Input/SpecialInput.cs
+++ b/Yam.Core/Rhythm/Input/SpecialInput.cs
@@ -61,4 +61,14 @@ public class SpecialInput : IRhythmInput
     {
         return RhythmActionType.Invalid;
     }
+
+    public void Start()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Release()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/Yam.Core/Rhythm/Schemas/SchemaTerminology.md
+++ b/Yam.Core/Rhythm/Schemas/SchemaTerminology.md
@@ -1,11 +1,19 @@
 # Schema Terminology and Discussion
 
+## Rhythm terminology
+
 1. The rhythm game looks at **Charts**.
 2. **Charts** are composed of metadata and a list of **Beats**.
 3. A **Beat** is the smallest unit of player interaction with a combined singular judgment for all its parts. A **Beat** is *exclusively either*: (Hint to self: use oneOf https://stackoverflow.com/a/25033301/17836168)
    1. A metadata about what it is so the game knows how to parse it AND a list of **Ticks**.
    2. A metadata about what it is AND properties in a **Tick** (Hint: use allOf https://stackoverflow.com/a/52579526/17836168)
 4. A **Tick** is the smallest unit of player interaction. It's composed of the origin point, and an optional two anchor points for **Beats** that use Bézier curves.
+
+## Game terminology
+
+1. Game refers to functions that are implemented or set in Godot. Do not use the term Godot due to naming conflict.
+2. Player refers to the source of human input. The person playing the game. It should not be confused with simulator.
+3. Simulator refers to systems that players do not have direct control of, and are invoked by the game loop or game events.
 
 **Types of Beat**
 

--- a/Yam.Core/Yam.Core.csproj
+++ b/Yam.Core/Yam.Core.csproj
@@ -17,5 +17,6 @@
 
     <ItemGroup>
       <PackageReference Include="GodotSharp" Version="4.2.1" />
+      <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     </ItemGroup>
 </Project>

--- a/Yam.Game/Scripts/Rhythm/Dev/IParsedTick.cs
+++ b/Yam.Game/Scripts/Rhythm/Dev/IParsedTick.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Yam.Game.Scripts.Rhythm.Dev;
+
+public interface IParsedTick
+{
+    float GetTime();
+    float GetUCoord();
+    bool IsComplex();
+    bool TryContainTick(IParsedTick tick);
+    List<IParsedTick> GetTickList();
+}

--- a/Yam.Game/Scripts/Rhythm/Dev/ParseOsu.cs
+++ b/Yam.Game/Scripts/Rhythm/Dev/ParseOsu.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Godot;
+using Yam.Core.Common;
 
 namespace Yam.Game.Scripts.Rhythm.Dev;
 
@@ -41,14 +42,14 @@ public partial class ParseOsu : Node
         using var f = FileAccess.Open(OsuSourceFile, FileAccess.ModeFlags.Read);
         if (f == null)
         {
-            GD.PrintErr("ParseOsu: Missing osu file");
+            GameLogger.PrintErr("ParseOsu: Missing osu file");
             return;
         }
 
         using var resultFile = FileAccess.Open(JsonResultFile, FileAccess.ModeFlags.Write);
         if (resultFile == null)
         {
-            GD.PrintErr("ParseOsu: Missing target result file");
+            GameLogger.PrintErr("ParseOsu: Missing target result file");
             return;
         }
 
@@ -143,6 +144,6 @@ public partial class ParseOsu : Node
         });
 
         resultFile.StoreString($"[\n{string.Join(",\n", rawBeatStrings.ToArray())}\n]");
-        GD.Print("Finished parsing osu file");
+        GameLogger.Print("Finished parsing osu file");
     }
 }

--- a/Yam.Game/Scripts/Rhythm/Dev/ParsedBeatObject.cs
+++ b/Yam.Game/Scripts/Rhythm/Dev/ParsedBeatObject.cs
@@ -1,38 +1,36 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using Godot;
 
 namespace Yam.Game.Scripts.Rhythm.Dev;
 
 public class ParsedBeatObject : IParsedTick
 {
-    public List<IParsedTick> parsedTickList = new();
+    private readonly List<IParsedTick> _parsedTickList = new();
 
     public ParsedBeatObject(string startTime, string endTime)
     {
-        parsedTickList.Add(new ParsedTick(startTime, "0"));
-        parsedTickList.Add(new ParsedTick(endTime.Split(':')[0], "0"));
+        _parsedTickList.Add(new ParsedTick(startTime, "0"));
+        _parsedTickList.Add(new ParsedTick(endTime.Split(':')[0], "0"));
     }
 
     public float GetTime()
     {
-        if (parsedTickList.Count == 0)
+        if (_parsedTickList.Count == 0)
         {
             return -1;
         }
 
-        return parsedTickList[0].GetTime();
+        return _parsedTickList[0].GetTime();
     }
-    
+
     public float GetUCoord()
     {
-        if (parsedTickList.Count == 0)
+        if (_parsedTickList.Count == 0)
         {
             return -1;
         }
 
-        return parsedTickList[0].GetUCoord();
+        return _parsedTickList[0].GetUCoord();
     }
 
     public bool IsComplex()
@@ -42,19 +40,18 @@ public class ParsedBeatObject : IParsedTick
 
     public bool TryContainTick(IParsedTick parsedTick)
     {
-        var isContained = parsedTickList[0].GetTime() < parsedTick.GetTime()
-                          && parsedTick.GetTime() < parsedTickList.Last().GetTime();
+        var isContained = _parsedTickList[0].GetTime() < parsedTick.GetTime()
+                          && parsedTick.GetTime() < _parsedTickList.Last().GetTime();
 
         if (isContained)
         {
-            for (var i = 0; i < parsedTickList.Count; i++)
+            for (var i = 0; i < _parsedTickList.Count; i++)
             {
-                if (parsedTickList[i].GetTime() > parsedTick.GetTime())
+                if (_parsedTickList[i].GetTime() > parsedTick.GetTime())
                 {
-                    parsedTickList.Insert(i, parsedTick);
+                    _parsedTickList.Insert(i, parsedTick);
                     break;
                 }
-                
             }
         }
 
@@ -63,53 +60,6 @@ public class ParsedBeatObject : IParsedTick
 
     public List<IParsedTick> GetTickList()
     {
-        return parsedTickList;
+        return _parsedTickList;
     }
-}
-
-// todo: extract class to a new file but put here for now
-public class ParsedTick : IParsedTick
-{
-    public float Time;
-    public float UCoord;
-
-    public ParsedTick(string time, string x)
-    {
-        Time = float.Parse(time, CultureInfo.InvariantCulture) / 1000f;
-        UCoord = Mathf.Round(float.Parse(x, CultureInfo.InvariantCulture) / 103f) * 128f;
-    }
-
-    public float GetTime()
-    {
-        return Time;
-    }
-
-    public float GetUCoord()
-    {
-        return UCoord;
-    }
-
-    public bool IsComplex()
-    {
-        return false;
-    }
-
-    public bool TryContainTick(IParsedTick tick)
-    {
-        return false;
-    }
-
-    public List<IParsedTick> GetTickList()
-    {
-        return new List<IParsedTick>();
-    }
-}
-
-public interface IParsedTick
-{
-    float GetTime();
-    float GetUCoord();
-    bool IsComplex();
-    bool TryContainTick(IParsedTick tick);
-    List<IParsedTick> GetTickList();
 }

--- a/Yam.Game/Scripts/Rhythm/Dev/ParsedTick.cs
+++ b/Yam.Game/Scripts/Rhythm/Dev/ParsedTick.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Godot;
+
+namespace Yam.Game.Scripts.Rhythm.Dev;
+
+public class ParsedTick : IParsedTick
+{
+    public float Time;
+    public float UCoord;
+
+    public ParsedTick(string time, string x)
+    {
+        Time = float.Parse(time, CultureInfo.InvariantCulture) / 1000f;
+        UCoord = Mathf.Round(float.Parse(x, CultureInfo.InvariantCulture) / 103f) * 128f;
+    }
+
+    public float GetTime()
+    {
+        return Time;
+    }
+
+    public float GetUCoord()
+    {
+        return UCoord;
+    }
+
+    public bool IsComplex()
+    {
+        return false;
+    }
+
+    public bool TryContainTick(IParsedTick tick)
+    {
+        return false;
+    }
+
+    public List<IParsedTick> GetTickList()
+    {
+        return new List<IParsedTick>();
+    }
+}

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
@@ -1,4 +1,5 @@
 using Godot;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 using Yam.Game.Scripts.Rhythm.Game.SingleBeat;
 
@@ -30,7 +31,7 @@ public partial class HoldPiece : Node2D
 
         if (StartBeat == null)
         {
-            GD.PrintErr($"Failed creating start beat: {startBeat.Time}");
+            GameLogger.PrintErr($"Failed creating start beat: {startBeat.Time}");
             return;
         }
 

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
@@ -83,7 +83,7 @@ public partial class SingleBeat : Node2D, IBeatVisualizer
     public void InformEndResult(BeatInputResult result)
     {
         // todo(turnip): add effects
-        GD.Print("Result received in Godot: ", result.ToString());
+        GameLogger.Print("Result received in Godot: ", result.ToString());
         ReleaseSelf();
     }
 }

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
@@ -5,7 +5,7 @@ using Yam.Core.Rhythm.Chart;
 
 namespace Yam.Game.Scripts.Rhythm.Game.SingleBeat;
 
-public partial class SingleBeat : Node2D
+public partial class SingleBeat : Node2D, IBeatVisualizer
 {
     public bool IsActive { get; set; }
 
@@ -39,13 +39,19 @@ public partial class SingleBeat : Node2D
 
         if (Position.X > RhythmPlayer.DestructionPoint.Position.X)
         {
-            IsActive = false;
-            Pooler.Release(this);
+            ReleaseSelf();
+        }
+    }
 
-            while (_releaseListeners.Count > 0)
-            {
-                _releaseListeners.Pop().Trigger();
-            }
+    private void ReleaseSelf()
+    {
+        IsActive = false;
+        Visible = false;
+        Pooler.Release(this);
+
+        while (_releaseListeners.Count > 0)
+        {
+            _releaseListeners.Pop().Trigger();
         }
     }
 
@@ -59,9 +65,11 @@ public partial class SingleBeat : Node2D
         args.Beat.IsVisualized = true;
         RhythmPlayer = args.RhythmPlayer;
         Beat = args.Beat;
+        args.Beat.SetVisualizer(this);
         Position = Position with { Y = RhythmPlayer.TriggerPoint.Position.Y + _beat.UCoord };
         IsActive = true;
         Name = $"SingleBeat: {Beat.GetVector()}";
+        Visible = true;
     }
 
     public static float TimeToX(RhythmPlayer rhythmPlayer, float time)
@@ -70,5 +78,12 @@ public partial class SingleBeat : Node2D
                + ((rhythmPlayer.GetCurrentSongTime() - (time - rhythmPlayer.PreEmptDuration)) *
                   (rhythmPlayer.TriggerPoint.Position.X - rhythmPlayer.SpawnPoint.Position.X))
                / (rhythmPlayer.PreEmptDuration);
+    }
+
+    public void InformEndResult(BeatInputResult result)
+    {
+        // todo(turnip): add effects
+        GD.Print("Result received in Godot: ", result.ToString());
+        ReleaseSelf();
     }
 }

--- a/Yam.Game/Scripts/Rhythm/Input/GodotInputProvider.cs
+++ b/Yam.Game/Scripts/Rhythm/Input/GodotInputProvider.cs
@@ -48,9 +48,9 @@ public class GodotInputProvider : IRhythmInputProvider
             {
                 singularInput.Release();
                 return singularInput;
-            } else if ((@event.IsActionReleased(keyCode)))
+            } else if ((@event.IsActionPressed(keyCode)))
             {
-                singularInput.Start();
+                singularInput.Activate();
                 return singularInput;
             }
         }

--- a/Yam.Game/Scripts/Rhythm/Input/GodotInputProvider.cs
+++ b/Yam.Game/Scripts/Rhythm/Input/GodotInputProvider.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using Godot;
 using Yam.Core.Rhythm.Input;
-using In = Godot.Input;
 
 namespace Yam.Game.Scripts.Rhythm.Input;
 
 public class GodotInputProvider : IRhythmInputProvider
 {
-    public const string Keyboard1Up = "keyboard1_up";
+    private const string Keyboard1Up = "keyboard1_up";
 
     // 2 slides + input combo then 6 more solo input combos
     private List<IRhythmInput> _activeInputList = new();
@@ -37,58 +36,25 @@ public class GodotInputProvider : IRhythmInputProvider
 
     public List<ISingularInput> GetSingularInputList()
     {
-        // todo: fix
         return _keyboardSingularInputList;
-    }
-
-    public void PollInput()
-    {
-        // because it's complex
-        // _keyboardDirectionInput.Direction = Vector2.Zero;
-        //
-        // if (In.IsActionPressed("keyboard1_up"))
-        // {
-        //     _keyboardDirectionInput.Direction = Vector2.Up;
-        // }
-        // else if (In.IsActionPressed("keyboard1_down"))
-        // {
-        //     _keyboardDirectionInput.Direction = Vector2.Down;
-        // }
-        //
-        // if (In.IsActionPressed("keyboard1_left"))
-        // {
-        //     _keyboardDirectionInput.Direction += Vector2.Left;
-        // } else if (In.IsActionPressed("keyboard1_right"))
-        // {
-        //     _keyboardDirectionInput.Direction += Vector2.Right;
-        // }
-
-        // if (_keyboardDirectionInput.GetClaimingChannel() != null)
-        // {
-        //     foreach (var code in _keyboardSingularInputList)
-        //     {
-        //         // todo(turnip): 
-        //     }
-        // }
     }
 
     public IRhythmInput ProcessEvent(InputEvent @event)
     {
-        if (@event.IsAction(Keyboard1Up, true))
+        foreach (var singularInput in _keyboardSingularInputList)
         {
-            // todo(turnip): consider difference with just pressed and held state buffer?
-            if (@event.IsActionReleased(Keyboard1Up))
+            var keyCode = singularInput.GetInputCode();
+            if (@event.IsActionReleased(keyCode))
             {
-                _keyboardUp.Release();
-            }
-            else
+                singularInput.Release();
+                return singularInput;
+            } else if ((@event.IsActionReleased(keyCode)))
             {
-                _keyboardUp.Press();
+                singularInput.Start();
+                return singularInput;
             }
-
-            return _keyboardUp;
         }
-
+        
         return SpecialInput.UnknownInput;
     }
 }

--- a/Yam.Game/Scripts/Rhythm/RhythmPlayer.cs
+++ b/Yam.Game/Scripts/Rhythm/RhythmPlayer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using Godot;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 using Yam.Core.Rhythm.Input;
 using Yam.Game.Scripts.Rhythm.Game.SingleBeat;
@@ -127,7 +128,7 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
         using var f = FileAccess.Open(Chart.ResourcePath, FileAccess.ModeFlags.Read);
         if (f == null)
         {
-            GD.PrintErr("Chart: Missing Chart file");
+            GameLogger.PrintErr("Chart: Missing Chart file");
             return;
         }
 
@@ -135,7 +136,7 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
         _chartModel = ChartModel.FromEntity(chartEntity, RelativeReactionWindow);
 
         // todo(turnip): remove
-        GD.Print("Done parsing");
+        GameLogger.Print("Done parsing");
 
         // todo(turnip): choose music based on chart instead of hardcoded-ish here
     }


### PR DESCRIPTION
## What's this change for?

Implement working input reacting with singular beats.

## Detailed description

- Integrate input and beat logic (both in Yam.Core) interaction in Yam.Game
- Add GameLogger to allow logs both in xUnit and Godot
- Added `troubleshooting.md` for possible errors.
