### PR TITLE
Implement hold and release action

### DIFF
--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -1,7 +1,6 @@
 using JetBrains.Annotations;
 using Moq;
 using Xunit.Abstractions;
-using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 using Yam.Core.Rhythm.Input;
 using Yam.Core.Test.Utility;
@@ -46,13 +45,13 @@ public abstract class BeatTest
 
             var first3 = BeatUtil.NewHoldBeat_OverlapTest(1f, 2.1f);
             var second3 = BeatUtil.NewHoldBeat_OverlapTest(2f, 3f);
-            Assert.True(first2.Overlaps(second3));
+            Assert.True(first3.Overlaps(second3));
         }
     }
 
     public class SimulateSingleBeat : BaseTest
     {
-        public SimulateSingleBeat(ITestOutputHelper output) : base(output)
+        public SimulateSingleBeat(ITestOutputHelper xUnitLogger) : base(xUnitLogger)
         {
         }
 
@@ -60,7 +59,7 @@ public abstract class BeatTest
         public void BeatLifecycle()
         {
             var beatTime = 10f;
-            var beat = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime));
+            var beat = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime), XUnitLogger);
 
             var rhythmPlayer = new Mock<IRhythmPlayer>();
             var playerInput = new Mock<IRhythmInput>();
@@ -93,8 +92,8 @@ public abstract class BeatTest
         public void InputCannotBeClaimedTwice()
         {
             var beatTime = 10f;
-            var beat1 = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime));
-            var beat2 = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime));
+            var beat1 = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime), XUnitLogger);
+            var beat2 = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime), XUnitLogger);
 
             var rhythmPlayer = new Mock<IRhythmPlayer>();
             var playerInput = new Mock<IRhythmInput>();
@@ -126,7 +125,7 @@ public abstract class BeatTest
 
     public class SimulateHoldBeat : BaseTest
     {
-        public SimulateHoldBeat(ITestOutputHelper output) : base(output)
+        public SimulateHoldBeat(ITestOutputHelper xUnitLogger) : base(xUnitLogger)
         {
         }
 
@@ -140,7 +139,9 @@ public abstract class BeatTest
             {
                 new BeatEntity(startTime),
                 new BeatEntity(endTime),
-            });
+            }, XUnitLogger);
+            beat.Logger.XUnitLogger = XUnitLogger;
+
 
             var rhythmPlayer = new Mock<IRhythmPlayer>();
             var playerInput = new Mock<IRhythmInput>();
@@ -172,10 +173,10 @@ public abstract class BeatTest
 
             rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns((startTime + endTime) / 2f);
             Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput));
-            
+
             rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(endTime);
             Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput));
-            
+
             beat.OnInputRelease();
             Assert.Equal(BeatInputResult.Excellent, beat.HoldReleaseResult);
         }
@@ -199,9 +200,9 @@ public abstract class BeatTest
         // todo(turnip): too early, good, ok
 
         // todo(turnip): input is already claimed and miss
-        
+
         // todo(turnip): handle input switching when there are two holds that end at different times
-        
+
         // todo(turnip): handle input switching when there is a hold and a beat
     }
 }

--- a/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
@@ -1,15 +1,21 @@
 using JetBrains.Annotations;
 using Moq;
+using Xunit.Abstractions;
 using Yam.Core.Rhythm.Chart;
 using Yam.Core.Rhythm.Input;
+using Yam.Core.Test.Utility;
 
 namespace Yam.Core.Test.Rhythm.Input;
 
 [TestSubject(typeof(KeyboardSingularInput))]
 public abstract class KeyboardSingularInputTest
 {
-    public class Lifecycle
+    public class Lifecycle: BaseTest
     {
+        public Lifecycle(ITestOutputHelper output) : base(output)
+        {
+        }
+        
         [Fact]
         public void SimulateClaimingLifecycle()
         {
@@ -33,8 +39,8 @@ public abstract class KeyboardSingularInputTest
             // on release, all claims are released also, and the claimer will be informed
             // note: that we have to be very careful with this
             input.Release();
-            beat.Verify(m => m.InformRelease(), Times.Once());
-            differentBeat.Verify(m => m.InformRelease(), Times.Never());
+            beat.Verify(m => m.OnInputRelease(), Times.Once());
+            differentBeat.Verify(m => m.OnInputRelease(), Times.Never());
         }
         
         [Fact]
@@ -84,8 +90,8 @@ public abstract class KeyboardSingularInputTest
             // on release, all claims are released also, and the claimer will be informed
             // note: that we have to be very careful with this
             input.Release();
-            beat.Verify(m => m.InformRelease(), Times.Once());
-            differentBeat.Verify(m => m.InformRelease(), Times.Never());
+            beat.Verify(m => m.OnInputRelease(), Times.Once());
+            differentBeat.Verify(m => m.OnInputRelease(), Times.Never());
         }
     }
 }

--- a/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
@@ -10,12 +10,8 @@ namespace Yam.Core.Test.Rhythm.Input;
 [TestSubject(typeof(KeyboardSingularInput))]
 public abstract class KeyboardSingularInputTest
 {
-    public class Lifecycle: BaseTest
+    public class Lifecycle
     {
-        public Lifecycle(ITestOutputHelper output) : base(output)
-        {
-        }
-        
         [Fact]
         public void SimulateClaimingLifecycle()
         {

--- a/Yam.Core.Test/Utility/BaseTest.cs
+++ b/Yam.Core.Test/Utility/BaseTest.cs
@@ -1,0 +1,12 @@
+using Xunit.Abstractions;
+using Yam.Core.Common;
+
+namespace Yam.Core.Test.Utility;
+
+public abstract class BaseTest
+{
+    protected BaseTest(ITestOutputHelper output)
+    {
+        GameLogger.Output = output;
+    }
+}

--- a/Yam.Core.Test/Utility/BaseTest.cs
+++ b/Yam.Core.Test/Utility/BaseTest.cs
@@ -5,8 +5,10 @@ namespace Yam.Core.Test.Utility;
 
 public abstract class BaseTest
 {
-    protected BaseTest(ITestOutputHelper output)
+    protected readonly ITestOutputHelper XUnitLogger;
+
+    protected BaseTest(ITestOutputHelper xUnitLogger)
     {
-        GameLogger.Output = output;
+        XUnitLogger = xUnitLogger;
     }
 }

--- a/Yam.Core.Test/Utility/BeatUtil.cs
+++ b/Yam.Core.Test/Utility/BeatUtil.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Xunit.Abstractions;
 using Yam.Core.Rhythm.Chart;
 
 namespace Yam.Core.Test.Utility;
@@ -19,16 +20,16 @@ public static class BeatUtil
         return beat;
     }
 
-    public static Beat NewSingleBeat(BeatEntity beatEntity)
+    public static Beat NewSingleBeat(BeatEntity beatEntity, ITestOutputHelper xUnitLogger)
     {
-        return Beat.FromEntity(beatEntity, Beat.DefaultRelativeReactionWindow);
+        return Beat.FromEntity(beatEntity, Beat.DefaultRelativeReactionWindow, xUnitLogger);
     }
     
-    public static Beat NewHoldBeat(List<BeatEntity> beatEntityList)
+    public static Beat NewHoldBeat(List<BeatEntity> beatEntityList, ITestOutputHelper xUnitLogger)
     {
         Debug.Assert(beatEntityList.Count > 0);
         var baseBeat = beatEntityList[0].ShallowClone();
         baseBeat.BeatList = beatEntityList;
-        return Beat.FromEntity(baseBeat, Beat.DefaultRelativeReactionWindow);
+        return Beat.FromEntity(baseBeat, Beat.DefaultRelativeReactionWindow,xUnitLogger);
     }
 }

--- a/Yam.Core.Test/Utility/BeatUtil.cs
+++ b/Yam.Core.Test/Utility/BeatUtil.cs
@@ -5,7 +5,7 @@ namespace Yam.Core.Test.Utility;
 
 public static class BeatUtil
 {
-    public static Beat NewHoldBeat(float startTime, float endTime)
+    public static Beat NewHoldBeat_OverlapTest(float startTime, float endTime)
     {
         Debug.Assert(startTime < endTime);
         var beat = new Beat
@@ -22,5 +22,13 @@ public static class BeatUtil
     public static Beat NewSingleBeat(BeatEntity beatEntity)
     {
         return Beat.FromEntity(beatEntity, Beat.DefaultRelativeReactionWindow);
+    }
+    
+    public static Beat NewHoldBeat(List<BeatEntity> beatEntityList)
+    {
+        Debug.Assert(beatEntityList.Count > 0);
+        var baseBeat = beatEntityList[0].ShallowClone();
+        baseBeat.BeatList = beatEntityList;
+        return Beat.FromEntity(baseBeat, Beat.DefaultRelativeReactionWindow);
     }
 }

--- a/Yam.Core/Common/GameLogger.cs
+++ b/Yam.Core/Common/GameLogger.cs
@@ -6,15 +6,15 @@ namespace Yam.Core.Common;
 // todo(turnip): improve GameLogger by detecting that we're being run in xUnit
 // and ignore any calls to Godot. Or check if Godot's GD global function specific
 // to Print is available for use
-public static class GameLogger
+public class GameLogger
 {
-    public static ITestOutputHelper? Output;
+    public ITestOutputHelper? XUnitLogger;
 
-    public static void Print(params string[] what)
+    public void Print(params string[] what)
     {
-        if (Output != null)
+        if (XUnitLogger != null)
         {
-            Output.WriteLine(what.Join(""));
+            XUnitLogger.WriteLine(what.Join(""));
         }
         else
         {
@@ -22,11 +22,11 @@ public static class GameLogger
         }
     }
     
-    public static void PrintErr(string what)
+    public void PrintErr(string what)
     {
-        if (Output != null)
+        if (XUnitLogger != null)
         {
-            Output.WriteLine($"Godot.PrintErr: {what}");
+            XUnitLogger.WriteLine($"Godot.PrintErr: {what}");
         }
         else
         {

--- a/Yam.Core/Common/GenericPooler.cs
+++ b/Yam.Core/Common/GenericPooler.cs
@@ -1,11 +1,12 @@
 #nullable enable
 using System.Collections.Generic;
-using Godot;
 
 namespace Yam.Core.Common;
 
 public abstract class GenericPooler<TPooledObject, TPooledObjectArgs>
 {
+    public GameLogger Logger = new();
+
     protected readonly List<TPooledObject> InUse = new();
     protected readonly Stack<TPooledObject> Available = new();
 
@@ -29,7 +30,7 @@ public abstract class GenericPooler<TPooledObject, TPooledObjectArgs>
 
         if (newObject == null)
         {
-            GameLogger.PrintErr("Instantiating Pooled Object failed");
+            Logger.PrintErr("Instantiating Pooled Object failed");
         }
         else
         {

--- a/Yam.Core/Rhythm/Chart/Beat.cs
+++ b/Yam.Core/Rhythm/Chart/Beat.cs
@@ -42,7 +42,20 @@ public class Beat : TimeUCoordVector, IBeat
 
     private List<ReactionWindow> _reactionWindowList = new();
 
-    public float EndTime => BeatList.Count == 0 ? Time : BeatList.Last().Time;
+    private float _endTime = -10;
+
+    public float EndTime
+    {
+        get
+        {
+            if (_endTime < -9)
+            {
+                _endTime = BeatList.Count == 0 ? Time : BeatList.Last().Time;
+            }
+
+            return _endTime;
+        }
+    }
 
     #region Beat State
 
@@ -81,6 +94,9 @@ public class Beat : TimeUCoordVector, IBeat
             var firstBeat = beat.BeatList[0];
             beat.Time = firstBeat.Time;
             beat.UCoord = firstBeat.UCoord;
+            beat.PIn = firstBeat.PIn;
+            beat.POut = firstBeat.POut;
+            beat._reactionWindowList = ReactionWindowsFromRelative(reactionWindow, beat.Time);
         }
 
         return beat;
@@ -135,7 +151,7 @@ public class Beat : TimeUCoordVector, IBeat
         {
             BeatType.Single => _simulateSingleBeat(rhythmPlayer, playerInput),
             BeatType.Slide => BeatInputResult.Ignore,
-            BeatType.Hold => BeatInputResult.Ignore,
+            BeatType.Hold => _simulateHoldBeat(rhythmPlayer, playerInput),
             _ => throw new ArgumentOutOfRangeException()
         };
 
@@ -153,7 +169,7 @@ public class Beat : TimeUCoordVector, IBeat
                 or BeatInputResult.Good
                 or BeatInputResult.Excellent:
                 _state = State.Done;
-                _visualizer?.InformEndResult(result);
+                _visualizer?.InformEndResult(result, this);
                 _visualizer = null;
                 break;
             case BeatInputResult.Holding:
@@ -213,13 +229,130 @@ public class Beat : TimeUCoordVector, IBeat
         return BeatInputResult.Anticipating;
     }
 
-    public void InformRelease()
+    #region Hold
+
+    private int _holdIndex;
+    private IRhythmPlayer? _rhythmPlayer;
+
+    // For hold, we need to store the following information:
+    // Hold Start (start)
+    // Hold consistency (between each tick)
+    // Hold release (final beat or final tick)
+    private BeatInputResult _simulateHoldBeat(IRhythmPlayer rhythmPlayer, IRhythmInput playerInput)
     {
-        // todo(turnip)
+        if (_state == State.Waiting)
+        {
+            return _simulateStartHold(rhythmPlayer, playerInput);
+        }
+
+        // todo(turnip): for holding with movement, make sure we are on track
+
+        // detecting release is handled at the bottom, we only handle possible late releases here
+        var lastBeat = BeatList.Last();
+        var okReaction = lastBeat._reactionWindowList[^2];
+        var currentTime = rhythmPlayer.GetCurrentSongTime();
+        if (currentTime >= okReaction.Range.Y)
+        {
+            _state = State.Done;
+            GameLogger.Print($"Missed Hold ({Time}, {UCoord})");
+            return BeatInputResult.Miss;
+        }
+
+        return BeatInputResult.Holding;
     }
+
+
+    private BeatInputResult _simulateStartHold(IRhythmPlayer rhythmPlayer, IRhythmInput playerInput)
+    {
+        var tooEarlyReaction = _reactionWindowList.Last();
+        var okReaction = _reactionWindowList[^2];
+        var currentTime = rhythmPlayer.GetCurrentSongTime();
+
+        if (_state != State.Waiting)
+        {
+            // todo(turnip): add test for this case
+            GameLogger.PrintErr($"Not expected result: ({Time}, {UCoord})");
+            return BeatInputResult.Ignore;
+        }
+
+
+        if (currentTime < tooEarlyReaction.Range.X)
+        {
+            return BeatInputResult.Idle;
+        }
+
+        if (currentTime >= okReaction.Range.Y)
+        {
+            _state = State.Done;
+            GameLogger.Print($"Missed hold start ({Time}, {UCoord}). OkRange ends at {okReaction.Range.Y}. Current time is {currentTime}");
+            return BeatInputResult.Miss;
+        }
+
+        if (playerInput.GetSource() != InputSource.Player
+            && playerInput.GetRhythmActionType() != RhythmActionType.Singular)
+        {
+            return BeatInputResult.Anticipating;
+        }
+
+        if (playerInput.GetClaimingChannel() == null && playerInput.ClaimOnStart(this))
+        {
+            foreach (var reactionWindow in _reactionWindowList.Where(reactionWindow =>
+                         reactionWindow.Range.X < currentTime && currentTime < reactionWindow.Range.Y))
+            {
+                // we need reference to this for the release time
+                _rhythmPlayer = rhythmPlayer;
+
+                // todo(turnip): inform initial beat of the result and animate
+                var result = reactionWindow.BeatInputResult;
+                // todo: think of how visualizing works later
+                _visualizer?.InformEndResult(result, this);
+                _visualizer = null;
+                GameLogger.Print("Start hold");
+                return BeatInputResult.Holding;
+            }
+        }
+
+        // the detected input does not apply for this beat since it's claimed by another one already
+        return BeatInputResult.Anticipating;
+    }
+
+    #endregion Hold
 
     public void SetVisualizer(IBeatVisualizer visualizer)
     {
         _visualizer = visualizer;
+    }
+
+    // todo: delete this variable when we find a better way to communicate a release to the hold beat visualizer
+    // then we can have a mock listening for the result of how this beat ends
+    public BeatInputResult HoldReleaseResult;
+
+    public void OnInputRelease()
+    {
+        var currentTime = _rhythmPlayer?.GetCurrentSongTime();
+        if (currentTime == null)
+        {
+            return;
+        }
+
+        var lastReactionWindow = BeatList.Last()._reactionWindowList;
+        foreach (var reactionWindow in lastReactionWindow.Where(reactionWindow =>
+                     reactionWindow.Range.X < currentTime && currentTime < reactionWindow.Range.Y))
+        {
+            // todo(turnip): inform initial beat of the result and animate
+            var result = reactionWindow.BeatInputResult;
+            GameLogger.Print($"Release: {result}");
+            // todo: figure out which visualizer we should call??? the hold beat???
+            // _visualizer?.InformEndResult(result, this);
+            // _visualizer = null;
+            _state = State.Done;
+            HoldReleaseResult = result;
+            // todo: inform beat channel next???
+            return;
+        }
+
+        HoldReleaseResult = BeatInputResult.Miss;
+        GameLogger.Print("Release too late!");
+        _state = State.Done;
     }
 }

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -7,6 +7,8 @@ namespace Yam.Core.Rhythm.Chart;
 
 public class BeatChannel : List<Beat>
 {
+    public GameLogger Logger = new();
+    
     private int _currentVisualizationIndex;
     private int _currentInputIndex;
 
@@ -60,11 +62,11 @@ public class BeatChannel : List<Beat>
             case BeatInputResult.Ok:
             case BeatInputResult.Good:
             case BeatInputResult.Excellent:
-                GameLogger.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord}): {result.ToString()}");
+                Logger.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord}): {result.ToString()}");
                 _currentInputIndex++;
                 break;
             case BeatInputResult.Ignore:
-                GameLogger.Print($"IGNORE: Finished with ({currentBeat!.Time}, {currentBeat.UCoord})");
+                Logger.Print($"IGNORE: Finished with ({currentBeat!.Time}, {currentBeat.UCoord})");
                 _currentInputIndex++;
                 break;
             case null:

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -50,9 +50,10 @@ public class BeatChannel : List<Beat>
         switch (result)
         {
             case BeatInputResult.Idle:
-                break;
             case BeatInputResult.Anticipating:
+            case BeatInputResult.Holding:
                 break;
+            case BeatInputResult.Done:
             case BeatInputResult.TooEarly:
             case BeatInputResult.Miss:
             case BeatInputResult.Bad:
@@ -61,8 +62,6 @@ public class BeatChannel : List<Beat>
             case BeatInputResult.Excellent:
                 GameLogger.Print($"Finished with ({currentBeat!.Time}, {currentBeat.UCoord}): {result.ToString()}");
                 _currentInputIndex++;
-                break;
-            case BeatInputResult.Holding:
                 break;
             case BeatInputResult.Ignore:
                 GameLogger.Print($"IGNORE: Finished with ({currentBeat!.Time}, {currentBeat.UCoord})");
@@ -75,5 +74,10 @@ public class BeatChannel : List<Beat>
         }
 
         // todo(turnip): send signal if there is a reaction
+    }
+
+    public float GetLatestInputTime()
+    {
+        return TryToGetBeatForInput()?.Time ?? 0f;
     }
 }

--- a/Yam.Core/Rhythm/Chart/BeatEntity.cs
+++ b/Yam.Core/Rhythm/Chart/BeatEntity.cs
@@ -20,4 +20,18 @@ public class BeatEntity : TimeUCoordVector
     public TimeUCoordVector? PIn { get; set; }
     public TimeUCoordVector? POut { get; set; }
     public List<BeatEntity> BeatList { get; set; } = new();
+
+    /// <summary>
+    /// Clones the fields in the beat but ignores BeatList
+    /// </summary>
+    /// <returns>BeatEntity</returns>
+    public BeatEntity ShallowClone()
+    {
+        var newBeat = new BeatEntity();
+        newBeat.Time = Time;
+        newBeat.UCoord = UCoord;
+        newBeat.PIn = PIn?.Clone();
+        newBeat.POut = POut?.Clone();
+        return newBeat;
+    }
 }

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -68,6 +68,8 @@ public class Chart
 
     public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput input)
     {
+        ChannelList.Sort((a, b) => a.GetLatestInputTime().CompareTo(b.GetLatestInputTime()));
+
         ChannelList.ForEach(c => c.SimulateBeatInput(rhythmPlayer, input));
     }
 }

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Godot;
 using Yam.Core.Common;
 using Yam.Core.Rhythm.Input;
 
@@ -8,6 +7,8 @@ namespace Yam.Core.Rhythm.Chart;
 
 public class Chart
 {
+    public GameLogger Logger = new();
+    
     public const int ChannelSize = 5;
 
     public List<BeatChannel> ChannelList { get; set; } = new(ChannelSize);
@@ -42,7 +43,8 @@ public class Chart
 
             if (!wasAdded)
             {
-                GameLogger.PrintErr($"Beat not added: {beat.Time}");
+                // todo(turnip): fix static call to logger figure out how to cancel logs in static context???
+                chart.Logger.PrintErr($"Beat not added: {beat.Time}");
             }
 
             // todo: take note of this logic

--- a/Yam.Core/Rhythm/Chart/IBeat.cs
+++ b/Yam.Core/Rhythm/Chart/IBeat.cs
@@ -1,7 +1,8 @@
+using Yam.Core.Rhythm.Input;
+
 namespace Yam.Core.Rhythm.Chart;
 
-public interface IBeat
+public interface IBeat: IRhythmInputListener
 {
-    void InformRelease();
     void SetVisualizer(IBeatVisualizer visualizer);
 }

--- a/Yam.Core/Rhythm/Chart/IBeatVisualizer.cs
+++ b/Yam.Core/Rhythm/Chart/IBeatVisualizer.cs
@@ -2,5 +2,5 @@ namespace Yam.Core.Rhythm.Chart;
 
 public interface IBeatVisualizer
 {
-    void InformEndResult(BeatInputResult result);
+    void InformEndResult(BeatInputResult result, IBeat beat);
 }

--- a/Yam.Core/Rhythm/Chart/TimeUCoordVector.cs
+++ b/Yam.Core/Rhythm/Chart/TimeUCoordVector.cs
@@ -15,4 +15,13 @@ public class TimeUCoordVector
     {
         return new Vector2(Time, UCoord);
     }
+
+    public TimeUCoordVector Clone()
+    {
+        return new TimeUCoordVector
+        {
+            Time = Time,
+            UCoord = UCoord
+        };
+    }
 }

--- a/Yam.Core/Rhythm/Input/IRhythmInput.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInput.cs
@@ -37,3 +37,8 @@ public interface IRhythmInput
     public void Activate();
     public void Release();
 }
+
+public interface IRhythmInputListener
+{
+    public void OnInputRelease();
+}

--- a/Yam.Core/Rhythm/Input/KeyboardDirectionInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardDirectionInput.cs
@@ -8,6 +8,8 @@ namespace Yam.Core.Rhythm.Input;
 // todo(turnip): refactor code to remove duplicates
 public class KeyboardDirectionInput
 {
+    public GameLogger Logger = new();
+    
     // todo(turnip): see if we can combine them into the details class below
     private Beat? _claimingBeat;
     public Vector2 Direction { get; set; }
@@ -29,7 +31,7 @@ public class KeyboardDirectionInput
             return false;
         }
 
-        GameLogger.Print("Input Claimed");
+        Logger.Print("Input Claimed");
         _claimingBeat = claimingBeat;
         return true;
     }

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -47,14 +47,12 @@ public class KeyboardSingularInput : ISingularInput
             return false;
         }
 
-        GameLogger.Print("Successfully claimed");
         _claimingBeat = claimingBeat;
         return true;
     }
 
     public void ReleaseInput()
     {
-        GameLogger.Print("Released ", _keyCode);
         _claimingBeat = null;
     }
 
@@ -88,7 +86,7 @@ public class KeyboardSingularInput : ISingularInput
     public void Release()
     {
         _singularInputState = SingularInputState.Free;
-        _claimingBeat?.InformRelease();
+        _claimingBeat?.OnInputRelease();
         _claimingBeat = null;
     }
 }

--- a/Yam.Core/Rhythm/Schemas/SchemaTerminology.md
+++ b/Yam.Core/Rhythm/Schemas/SchemaTerminology.md
@@ -74,3 +74,5 @@ distance or number of increments = (abs(P1 - P1_in)
 ```
 
 TODO: Set hold line pooler and tick pooler. Then we create hold beat object which manages hold line and tick pool. It returns these items to the pooler later too
+
+**Special note:** Issues with syncing audio with beat input. Here's the ideal way of doing it: https://rhythmquestgame.com/devlog/04.html

--- a/Yam.Game/.gitignore
+++ b/Yam.Game/.gitignore
@@ -1,5 +1,6 @@
 # Godot 4+ specific ignores
 .godot/
+Builds/
 
 # C# ignores
 bin

--- a/Yam.Game/Scripts/Rhythm/Dev/ParseOsu.cs
+++ b/Yam.Game/Scripts/Rhythm/Dev/ParseOsu.cs
@@ -42,14 +42,14 @@ public partial class ParseOsu : Node
         using var f = FileAccess.Open(OsuSourceFile, FileAccess.ModeFlags.Read);
         if (f == null)
         {
-            GameLogger.PrintErr("ParseOsu: Missing osu file");
+            GD.PrintErr("ParseOsu: Missing osu file");
             return;
         }
 
         using var resultFile = FileAccess.Open(JsonResultFile, FileAccess.ModeFlags.Write);
         if (resultFile == null)
         {
-            GameLogger.PrintErr("ParseOsu: Missing target result file");
+            GD.PrintErr("ParseOsu: Missing target result file");
             return;
         }
 
@@ -144,6 +144,6 @@ public partial class ParseOsu : Node
         });
 
         resultFile.StoreString($"[\n{string.Join(",\n", rawBeatStrings.ToArray())}\n]");
-        GameLogger.Print("Finished parsing osu file");
+        GD.Print("Finished parsing osu file");
     }
 }

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
@@ -6,7 +6,7 @@ using Yam.Game.Scripts.Rhythm.Game.SingleBeat;
 
 namespace Yam.Game.Scripts.Rhythm.Game.HoldBeat;
 
-public partial class HoldBeat : Node2D, IBasicListener
+public partial class HoldBeat : Node2D, IBasicListener, IBeatVisualizer
 {
     private Beat _mainBeat;
     private RhythmPlayer _rhythmPlayer;
@@ -33,6 +33,7 @@ public partial class HoldBeat : Node2D, IBasicListener
             var pooler = i == 0 ? _rhythmPlayer.SingleBeatPooler : _rhythmPlayer.TickPooler;
             var holdPiece = new HoldPiece();
             holdPiece.Initialize(_rhythmPlayer, _mainBeat.BeatList[i], _mainBeat.BeatList[i + 1], pooler, _mainBeat);
+            // todo(turnip): set visualizer here?
             AddChild(holdPiece);
 
             if (i == 0)
@@ -66,5 +67,10 @@ public partial class HoldBeat : Node2D, IBasicListener
     public void Trigger()
     {
         QueueFree();
+    }
+
+    public void InformEndResult(BeatInputResult result, IBeat beat)
+    {
+        throw new System.NotImplementedException();
     }
 }

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
@@ -31,7 +31,7 @@ public partial class HoldPiece : Node2D
 
         if (StartBeat == null)
         {
-            GameLogger.PrintErr($"Failed creating start beat: {startBeat.Time}");
+            GD.Print($"Failed creating start beat: {startBeat.Time}");
             return;
         }
 

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
@@ -83,7 +83,7 @@ public partial class SingleBeat : Node2D, IBeatVisualizer
     public void InformEndResult(BeatInputResult result, IBeat beat)
     {
         // todo(turnip): add effects
-        GameLogger.Print("Result received in Godot: ", result.ToString());
+        GD.Print("Result received in Godot: ", result.ToString());
         ReleaseSelf();
     }
 }

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
@@ -80,7 +80,7 @@ public partial class SingleBeat : Node2D, IBeatVisualizer
                / (rhythmPlayer.PreEmptDuration);
     }
 
-    public void InformEndResult(BeatInputResult result)
+    public void InformEndResult(BeatInputResult result, IBeat beat)
     {
         // todo(turnip): add effects
         GameLogger.Print("Result received in Godot: ", result.ToString());

--- a/Yam.Game/Scripts/Rhythm/RhythmPlayer.cs
+++ b/Yam.Game/Scripts/Rhythm/RhythmPlayer.cs
@@ -82,7 +82,7 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
         
         // relying on song start instead of getting playback position
         // we will have issues later when we enable pausing and song looping
-        // GameLogger.Print($"{_currentSongTime} vs {AudioStreamPlayer.GetPlaybackPosition()}");
+        // GD.Print($"{_currentSongTime} vs {AudioStreamPlayer.GetPlaybackPosition()}");
 
         // simulate idle time for input misses
         _chartModel.SimulateBeatInput(this, SpecialInput.GameInput);
@@ -128,7 +128,7 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
         using var f = FileAccess.Open(Chart.ResourcePath, FileAccess.ModeFlags.Read);
         if (f == null)
         {
-            GameLogger.PrintErr("Chart: Missing Chart file");
+            GD.PrintErr("Chart: Missing Chart file");
             return;
         }
 
@@ -136,7 +136,7 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
         _chartModel = ChartModel.FromEntity(chartEntity, RelativeReactionWindow);
 
         // todo(turnip): remove
-        GameLogger.Print("Done parsing");
+        GD.Print("Done parsing");
 
         // todo(turnip): choose music based on chart instead of hardcoded-ish here
     }

--- a/Yam.Game/export_presets.cfg
+++ b/Yam.Game/export_presets.cfg
@@ -1,0 +1,65 @@
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="Builds/Yam.exe"
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+
+[preset.0.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=false
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=true
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+application/export_angle=0
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"
+dotnet/include_scripts_content=false
+dotnet/include_debug_symbols=true
+dotnet/embed_build_outputs=false


### PR DESCRIPTION
# Implement hold and release action

## Detailed description

- Implement detecting a hold start, a hold release, and a hold release miss.
- Fix bug related to RhythmPlayer over prioritizing Channel 1 when there are nearby beats. Solution was to sort the beat channels from earliest to latest times.
- Fix GameLogger bug caused by using a global game logger. There are instances where a unit test will be the last to overwrite the logger. This unit test's class ends, but another unit test is still running relying on that logger so it crashes due to that.
