### PR TITLE
Rename RhythmPlayer to RhythmSimulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 [![.NET](https://github.com/TurnipXenon/Yam/actions/workflows/dotnet.yml/badge.svg)](https://github.com/TurnipXenon/Yam/actions/workflows/dotnet.yml)
 
-PLEASE DON"T READ NOT YET DONE!!! WE'RE PROTOTYPING :P
+Yam is a rhythm game. No concept or pitch outside of that just yet.
+
+## Currently development progress
+
+We recently finished implementing holds. The next goals are:
+
+1. Implement scenario where we press two holds and figure out which hold to prioritize during release. Check notebook for notes.
+2. Implement moving to follow holds.
+3. Implement ignoring moving to follow holds when the ticks are at the same uCoord AND no related anchors (POut to PIn).
+4. Implement slides.
+5. Implement scoring.
+6. Implement animations.
+7. Document design and interactions.
 
 ## OLD README
 

--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -61,30 +61,30 @@ public abstract class BeatTest
             var beatTime = 10f;
             var beat = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime), XUnitLogger);
 
-            var rhythmPlayer = new Mock<IRhythmPlayer>();
+            var rhythmSimulator = new Mock<IRhythmSimulator>();
             var playerInput = new Mock<IRhythmInput>();
             playerInput.Setup(i => i.GetRhythmActionType()).Returns(RhythmActionType.Singular);
 
             // start: too far
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime())
+            rhythmSimulator.Setup(r => r.GetCurrentSongTime())
                 .Returns(beatTime - (Beat.DefaultTooEarlyRadius + Beat.FrameEpsilon));
-            var tooFar = beat.SimulateInput(rhythmPlayer.Object, playerInput.Object);
+            var tooFar = beat.SimulateInput(rhythmSimulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Idle, tooFar);
 
             // within range but no inputs yet
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(beatTime - Beat.DefaultOkRadius);
-            var noInput = beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput);
+            rhythmSimulator.Setup(r => r.GetCurrentSongTime()).Returns(beatTime - Beat.DefaultOkRadius);
+            var noInput = beat.SimulateInput(rhythmSimulator.Object, SpecialInput.GameInput);
             Assert.Equal(BeatInputResult.Anticipating, noInput);
 
             // within range of excellent with input
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime())
+            rhythmSimulator.Setup(r => r.GetCurrentSongTime())
                 .Returns(beatTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
             playerInput.Setup(i => i.ClaimOnStart(beat)).Returns(true);
-            var excellentInput = beat.SimulateInput(rhythmPlayer.Object, playerInput.Object);
+            var excellentInput = beat.SimulateInput(rhythmSimulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Excellent, excellentInput);
 
             // check the beat after it's done
-            Assert.Equal(BeatInputResult.Done, beat.SimulateInput(rhythmPlayer.Object, playerInput.Object));
+            Assert.Equal(BeatInputResult.Done, beat.SimulateInput(rhythmSimulator.Object, playerInput.Object));
         }
 
 
@@ -95,23 +95,23 @@ public abstract class BeatTest
             var beat1 = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime), XUnitLogger);
             var beat2 = BeatUtil.NewSingleBeat(new BeatEntity(time: beatTime), XUnitLogger);
 
-            var rhythmPlayer = new Mock<IRhythmPlayer>();
+            var simulator = new Mock<IRhythmSimulator>();
             var playerInput = new Mock<IRhythmInput>();
             playerInput.Setup(i => i.GetRhythmActionType()).Returns(RhythmActionType.Singular);
 
             // within range of excellent with input
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime())
+            simulator.Setup(r => r.GetCurrentSongTime())
                 .Returns(beatTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
             playerInput.Setup(i => i.ClaimOnStart(beat1)).Returns(true);
-            var excellentInput = beat1.SimulateInput(rhythmPlayer.Object, playerInput.Object);
+            var excellentInput = beat1.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Excellent, excellentInput);
             playerInput.Setup(i => i.GetClaimingChannel()).Returns(beat1);
 
-            var anticipating = beat2.SimulateInput(rhythmPlayer.Object, playerInput.Object);
+            var anticipating = beat2.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Anticipating, anticipating);
 
             // check the beat after it's done
-            Assert.Equal(BeatInputResult.Done, beat1.SimulateInput(rhythmPlayer.Object, playerInput.Object));
+            Assert.Equal(BeatInputResult.Done, beat1.SimulateInput(simulator.Object, playerInput.Object));
         }
 
         // todo(turnip): cannot claim a beat when in held or release state
@@ -143,7 +143,7 @@ public abstract class BeatTest
             beat.Logger.XUnitLogger = XUnitLogger;
 
 
-            var rhythmPlayer = new Mock<IRhythmPlayer>();
+            var simulator = new Mock<IRhythmSimulator>();
             var playerInput = new Mock<IRhythmInput>();
             playerInput.Setup(i => i.GetRhythmActionType()).Returns(RhythmActionType.Singular);
 
@@ -151,31 +151,31 @@ public abstract class BeatTest
             Assert.Equal(BeatType.Hold, beat.GetBeatType());
 
             // start: too far
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime())
+            simulator.Setup(r => r.GetCurrentSongTime())
                 .Returns(startTime - (Beat.DefaultTooEarlyRadius + Beat.FrameEpsilon));
-            var tooFar = beat.SimulateInput(rhythmPlayer.Object, playerInput.Object);
+            var tooFar = beat.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Idle, tooFar);
 
             // within range but no inputs yet
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(startTime - Beat.DefaultOkRadius);
-            var noInput = beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput);
+            simulator.Setup(r => r.GetCurrentSongTime()).Returns(startTime - Beat.DefaultOkRadius);
+            var noInput = beat.SimulateInput(simulator.Object, SpecialInput.GameInput);
             Assert.Equal(BeatInputResult.Anticipating, noInput);
 
             // within range of excellent with input
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime())
+            simulator.Setup(r => r.GetCurrentSongTime())
                 .Returns(startTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
             playerInput.Setup(i => i.ClaimOnStart(beat)).Returns(true);
-            var holding = beat.SimulateInput(rhythmPlayer.Object, playerInput.Object);
+            var holding = beat.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Holding, holding);
 
             // check the beat after it's done
-            Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput));
+            Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(simulator.Object, SpecialInput.GameInput));
 
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns((startTime + endTime) / 2f);
-            Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput));
+            simulator.Setup(r => r.GetCurrentSongTime()).Returns((startTime + endTime) / 2f);
+            Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(simulator.Object, SpecialInput.GameInput));
 
-            rhythmPlayer.Setup(r => r.GetCurrentSongTime()).Returns(endTime);
-            Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(rhythmPlayer.Object, SpecialInput.GameInput));
+            simulator.Setup(r => r.GetCurrentSongTime()).Returns(endTime);
+            Assert.Equal(BeatInputResult.Holding, beat.SimulateInput(simulator.Object, SpecialInput.GameInput));
 
             beat.OnInputRelease();
             Assert.Equal(BeatInputResult.Excellent, beat.HoldReleaseResult);

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -20,7 +20,7 @@ public class BeatChannel : List<Beat>
     /**
      * Note that CurrentIndex increases
      */
-    public Beat? TryToGetBeatToVisualize(IRhythmPlayer rhythmPlayer)
+    public Beat? TryToGetBeatToVisualize(IRhythmSimulator rhythmSimulator)
     {
         if (_currentVisualizationIndex >= Count)
         {
@@ -29,8 +29,8 @@ public class BeatChannel : List<Beat>
 
         var currentBeat = this[_currentVisualizationIndex];
         
-        if (rhythmPlayer.GetCurrentSongTime() > currentBeat.Time - rhythmPlayer.GetPreEmptTime()
-            && rhythmPlayer.GetCurrentSongTime() < currentBeat.Time + rhythmPlayer.GetPreEmptTime())
+        if (rhythmSimulator.GetCurrentSongTime() > currentBeat.Time - rhythmSimulator.GetPreEmptTime()
+            && rhythmSimulator.GetCurrentSongTime() < currentBeat.Time + rhythmSimulator.GetPreEmptTime())
         {
             _currentVisualizationIndex++;
             return currentBeat;
@@ -44,10 +44,10 @@ public class BeatChannel : List<Beat>
         return _currentInputIndex >= Count ? null : this[_currentInputIndex];
     }
 
-    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput playerInput)
+    public void SimulateBeatInput(IRhythmSimulator rhythmSimulator, IRhythmInput playerInput)
     {
         var currentBeat = TryToGetBeatForInput();
-        var result = currentBeat?.SimulateInput(rhythmPlayer, playerInput);
+        var result = currentBeat?.SimulateInput(rhythmSimulator, playerInput);
 
         switch (result)
         {

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -54,12 +54,12 @@ public class Chart
         return chart;
     }
 
-    public List<Beat> GetVisualizableBeats(IRhythmPlayer rhythmPlayer)
+    public List<Beat> GetVisualizableBeats(IRhythmSimulator rhythmSimulator)
     {
         List<Beat> beats = new();
         ChannelList.ForEach(b =>
         {
-            var nb = b.TryToGetBeatToVisualize(rhythmPlayer);
+            var nb = b.TryToGetBeatToVisualize(rhythmSimulator);
             if (nb != null)
             {
                 beats.Add(nb);
@@ -68,10 +68,10 @@ public class Chart
         return beats;
     }
 
-    public void SimulateBeatInput(IRhythmPlayer rhythmPlayer, IRhythmInput input)
+    public void SimulateBeatInput(IRhythmSimulator rhythmSimulator, IRhythmInput input)
     {
         ChannelList.Sort((a, b) => a.GetLatestInputTime().CompareTo(b.GetLatestInputTime()));
 
-        ChannelList.ForEach(c => c.SimulateBeatInput(rhythmPlayer, input));
+        ChannelList.ForEach(c => c.SimulateBeatInput(rhythmSimulator, input));
     }
 }

--- a/Yam.Core/Rhythm/Chart/IRhythmSimulator.cs
+++ b/Yam.Core/Rhythm/Chart/IRhythmSimulator.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Yam.Core.Rhythm.Chart;
 
-public interface IRhythmPlayer
+public interface IRhythmSimulator
 {
     public float GetCurrentSongTime();
     public float GetPreEmptTime();

--- a/Yam.Core/Rhythm/Schemas/SchemaTerminology.md
+++ b/Yam.Core/Rhythm/Schemas/SchemaTerminology.md
@@ -46,7 +46,7 @@
   - Think about bezier holds later (based on possible sketches based on existing osu data. check out the gameplay for Sunleth Waterscape???)
   - Ticks within (bezier) holds are represented as individual beats in the osu mock up file. We've assigned x=103 (1st property in the HitObjects) as these inert parts.
 - [x] Parse data from beat-test.rhythm.json
-  - Start with RhythmPlayer.cs and mirroring the data in that json. Don't look ahead too much
+  - Start with RhythmSimulator.cs and mirroring the data in that json. Don't look ahead too much
 - [ ] Channels for parallel beats should be calculated on load (one during runtime) and you do some sort of logic where you group beats that overlap with each other
 
 **How to figure out which beats to visualize**

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
@@ -9,36 +9,36 @@ namespace Yam.Game.Scripts.Rhythm.Game.HoldBeat;
 public partial class HoldBeat : Node2D, IBasicListener, IBeatVisualizer
 {
     private Beat _mainBeat;
-    private RhythmPlayer _rhythmPlayer;
+    private RhythmSimulator _rhythmSimulator;
     /** HoldBeat handles instantiating _endBeat */
     private SingleBeat.SingleBeat _endSingleBeat;
 
     private bool _isActive = false;
 
-    public void Initialize(RhythmPlayer rhythmPlayer, Beat mainBeat)
+    public void Initialize(RhythmSimulator rhythmSimulator, Beat mainBeat)
     {
-        _rhythmPlayer = rhythmPlayer;
+        _rhythmSimulator = rhythmSimulator;
         _mainBeat = mainBeat;
         Name = $"HoldBeat({mainBeat.Time})";
         var endBeat = mainBeat.BeatList.Last();
-        _endSingleBeat = _rhythmPlayer.SingleBeatPooler.Request(new PooledSingleBeatArgs()
+        _endSingleBeat = _rhythmSimulator.SingleBeatPooler.Request(new PooledSingleBeatArgs()
         {
             Beat = endBeat,
-            RhythmPlayer = _rhythmPlayer
+            RhythmSimulator = _rhythmSimulator
         });
         _endSingleBeat.SubscribeToEnd(this);
 
         for (var i = 0; i < _mainBeat.BeatList.Count - 1; i++)
         {
-            var pooler = i == 0 ? _rhythmPlayer.SingleBeatPooler : _rhythmPlayer.TickPooler;
+            var pooler = i == 0 ? _rhythmSimulator.SingleBeatPooler : _rhythmSimulator.TickPooler;
             var holdPiece = new HoldPiece();
-            holdPiece.Initialize(_rhythmPlayer, _mainBeat.BeatList[i], _mainBeat.BeatList[i + 1], pooler, _mainBeat);
+            holdPiece.Initialize(_rhythmSimulator, _mainBeat.BeatList[i], _mainBeat.BeatList[i + 1], pooler, _mainBeat);
             // todo(turnip): set visualizer here?
             AddChild(holdPiece);
 
             if (i == 0)
             {
-                Position = Position with { Y = rhythmPlayer.TriggerPoint.Position.Y + _mainBeat.BeatList[i].UCoord };
+                Position = Position with { Y = rhythmSimulator.TriggerPoint.Position.Y + _mainBeat.BeatList[i].UCoord };
             }
         }
 
@@ -54,10 +54,10 @@ public partial class HoldBeat : Node2D, IBasicListener, IBeatVisualizer
         }
 
         // todo(turnip): cache position
-        var x = _rhythmPlayer.SpawnPoint.Position.X
-                + ((_rhythmPlayer.GetCurrentSongTime() - (_mainBeat.Time - _rhythmPlayer.PreEmptDuration)) *
-                   (_rhythmPlayer.TriggerPoint.Position.X - _rhythmPlayer.SpawnPoint.Position.X))
-                / (_rhythmPlayer.PreEmptDuration);
+        var x = _rhythmSimulator.SpawnPoint.Position.X
+                + ((_rhythmSimulator.GetCurrentSongTime() - (_mainBeat.Time - _rhythmSimulator.PreEmptDuration)) *
+                   (_rhythmSimulator.TriggerPoint.Position.X - _rhythmSimulator.SpawnPoint.Position.X))
+                / (_rhythmSimulator.PreEmptDuration);
 
         Position = Position with { X = x };
 

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
@@ -17,7 +17,7 @@ public partial class HoldPiece : Node2D
     private Vector2 _ogP2;
     private Vector2 _ogP2In;
 
-    public void Initialize(RhythmPlayer rhythmPlayer,
+    public void Initialize(RhythmSimulator rhythmSimulator,
         Beat startBeat,
         Beat endBeat,
         SingleBeatPooler pooler,
@@ -26,7 +26,7 @@ public partial class HoldPiece : Node2D
         StartBeat = pooler.Request(new PooledSingleBeatArgs()
         {
             Beat = startBeat,
-            RhythmPlayer = rhythmPlayer
+            RhythmSimulator = rhythmSimulator
         });
 
         if (StartBeat == null)
@@ -39,19 +39,19 @@ public partial class HoldPiece : Node2D
 
         // todo: find a better place
         _ogP1 = StartBeat.Beat.GetVector();
-        _ogP1.X = SingleBeat.SingleBeat.TimeToX(rhythmPlayer, startBeat.Time);
+        _ogP1.X = SingleBeat.SingleBeat.TimeToX(rhythmSimulator, startBeat.Time);
         if (startBeat.POut != null)
         {
             _ogP1Out = startBeat.POut.ToVector();
-            _ogP1Out.X = SingleBeat.SingleBeat.TimeToX(rhythmPlayer, _ogP1Out.X);
+            _ogP1Out.X = SingleBeat.SingleBeat.TimeToX(rhythmSimulator, _ogP1Out.X);
         }
 
         _ogP2 = _endBeat.GetVector();
-        _ogP2.X = SingleBeat.SingleBeat.TimeToX(rhythmPlayer, _endBeat.Time);
+        _ogP2.X = SingleBeat.SingleBeat.TimeToX(rhythmSimulator, _endBeat.Time);
         if (endBeat.PIn != null)
         {
             _ogP2In = endBeat.PIn.ToVector();
-            _ogP2In.X = SingleBeat.SingleBeat.TimeToX(rhythmPlayer, _ogP2In.X);
+            _ogP2In.X = SingleBeat.SingleBeat.TimeToX(rhythmSimulator, _ogP2In.X);
         }
         
         var p1DiffVector = _ogP1; // todo: reduce with outward p1 p1_out
@@ -62,7 +62,7 @@ public partial class HoldPiece : Node2D
                      * DivisionMultiplier;
         _increment = 1f / _divisions;
 
-        Position = new Vector2(_ogP1.X - SingleBeat.SingleBeat.TimeToX(rhythmPlayer, parentBeat.Time),
+        Position = new Vector2(_ogP1.X - SingleBeat.SingleBeat.TimeToX(rhythmSimulator, parentBeat.Time),
             startBeat.UCoord);
     }
 

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/PooledSingleBeatArgs.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/PooledSingleBeatArgs.cs
@@ -5,5 +5,5 @@ namespace Yam.Game.Scripts.Rhythm.Game.SingleBeat;
 public class PooledSingleBeatArgs
 {
     public Beat Beat { get; set; }
-    public RhythmPlayer RhythmPlayer { get; set; }
+    public RhythmSimulator RhythmSimulator { get; set; }
 }

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeat.cs
@@ -17,7 +17,7 @@ public partial class SingleBeat : Node2D, IBeatVisualizer
         set { _beat = value; }
     }
 
-    public RhythmPlayer RhythmPlayer { get; set; }
+    public RhythmSimulator RhythmSimulator { get; set; }
     public SingleBeatPooler Pooler { get; set; }
 
     private Stack<IBasicListener> _releaseListeners = new();
@@ -30,14 +30,14 @@ public partial class SingleBeat : Node2D, IBeatVisualizer
         }
 
         // todo(turnip): cache position
-        var x = RhythmPlayer.SpawnPoint.Position.X
-                + ((RhythmPlayer.GetCurrentSongTime() - (Beat.Time - RhythmPlayer.PreEmptDuration)) *
-                   (RhythmPlayer.TriggerPoint.Position.X - RhythmPlayer.SpawnPoint.Position.X))
-                / (RhythmPlayer.PreEmptDuration);
+        var x = RhythmSimulator.SpawnPoint.Position.X
+                + ((RhythmSimulator.GetCurrentSongTime() - (Beat.Time - RhythmSimulator.PreEmptDuration)) *
+                   (RhythmSimulator.TriggerPoint.Position.X - RhythmSimulator.SpawnPoint.Position.X))
+                / (RhythmSimulator.PreEmptDuration);
 
         Position = Position with { X = x };
 
-        if (Position.X > RhythmPlayer.DestructionPoint.Position.X)
+        if (Position.X > RhythmSimulator.DestructionPoint.Position.X)
         {
             ReleaseSelf();
         }
@@ -63,21 +63,21 @@ public partial class SingleBeat : Node2D, IBeatVisualizer
     public void Initialize(PooledSingleBeatArgs args)
     {
         args.Beat.IsVisualized = true;
-        RhythmPlayer = args.RhythmPlayer;
+        RhythmSimulator = args.RhythmSimulator;
         Beat = args.Beat;
         args.Beat.SetVisualizer(this);
-        Position = Position with { Y = RhythmPlayer.TriggerPoint.Position.Y + _beat.UCoord };
+        Position = Position with { Y = RhythmSimulator.TriggerPoint.Position.Y + _beat.UCoord };
         IsActive = true;
         Name = $"SingleBeat: {Beat.GetVector()}";
         Visible = true;
     }
 
-    public static float TimeToX(RhythmPlayer rhythmPlayer, float time)
+    public static float TimeToX(RhythmSimulator rhythmSimulator, float time)
     {
-        return rhythmPlayer.SpawnPoint.Position.X
-               + ((rhythmPlayer.GetCurrentSongTime() - (time - rhythmPlayer.PreEmptDuration)) *
-                  (rhythmPlayer.TriggerPoint.Position.X - rhythmPlayer.SpawnPoint.Position.X))
-               / (rhythmPlayer.PreEmptDuration);
+        return rhythmSimulator.SpawnPoint.Position.X
+               + ((rhythmSimulator.GetCurrentSongTime() - (time - rhythmSimulator.PreEmptDuration)) *
+                  (rhythmSimulator.TriggerPoint.Position.X - rhythmSimulator.SpawnPoint.Position.X))
+               / (rhythmSimulator.PreEmptDuration);
     }
 
     public void InformEndResult(BeatInputResult result, IBeat beat)

--- a/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeatPooler.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/SingleBeat/SingleBeatPooler.cs
@@ -7,7 +7,7 @@ namespace Yam.Game.Scripts.Rhythm.Game.SingleBeat;
 
 public class SingleBeatPooler : GenericPooler<SingleBeat, PooledSingleBeatArgs>
 {
-    private readonly RhythmPlayer _rhythmPlayer;
+    private readonly RhythmSimulator _rhythmSimulator;
     private readonly PackedScene _prefab;
 
     protected override SingleBeat? InstantiatePooledObject(PooledSingleBeatArgs args)
@@ -20,14 +20,14 @@ public class SingleBeatPooler : GenericPooler<SingleBeat, PooledSingleBeatArgs>
         var singleBeat = _prefab.Instantiate<SingleBeat>();
         singleBeat.Initialize(args);
         
-        singleBeat.RhythmPlayer.Parent.AddChild(singleBeat);
+        singleBeat.RhythmSimulator.Parent.AddChild(singleBeat);
         singleBeat.Pooler = this;
         return singleBeat;
     }
 
-    public SingleBeatPooler(RhythmPlayer rhythmPlayer, PackedScene prefab)
+    public SingleBeatPooler(RhythmSimulator rhythmSimulator, PackedScene prefab)
     {
-        _rhythmPlayer = rhythmPlayer;
+        _rhythmSimulator = rhythmSimulator;
         _prefab = prefab;
     }
 

--- a/Yam.Game/Scripts/Rhythm/RhythmSimulator.cs
+++ b/Yam.Game/Scripts/Rhythm/RhythmSimulator.cs
@@ -14,7 +14,7 @@ using HoldBeat = Yam.Game.Scripts.Rhythm.Game.HoldBeat.HoldBeat;
 
 namespace Yam.Game.Scripts.Rhythm;
 
-public partial class RhythmPlayer : Node, IRhythmPlayer
+public partial class RhythmSimulator : Node, IRhythmSimulator
 {
     [Export] public Resource Chart { get; set; }
     [Export] public AudioStreamPlayer AudioStreamPlayer { get; set; }
@@ -103,7 +103,7 @@ public partial class RhythmPlayer : Node, IRhythmPlayer
                     SingleBeatPooler.Request(new PooledSingleBeatArgs()
                     {
                         Beat = beat,
-                        RhythmPlayer = this
+                        RhythmSimulator = this
                     });
                     break;
 


### PR DESCRIPTION
## What's this change for?

I found player confusing so I renamed it to simulator to indicate it simulates a system. Now, I use player to mean anything related to the relevant state or input of the player.
