### PR TITLE
Implement simultaneous hold

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,33 @@
 Enter your brief description for the pull request
 
 ## What's this change for?
+
 This closes / fixes / resolves #ISSUE_NUMBER ISSUE_TITLE .
 
 Add more info below.
 
 ## Detailed description
-Put technical details and detailed specifications here. Add a special header for
-special details that need a distinct section, and make it a subheader of this.
+
+Put technical details and detailed specifications here. Add a special header for special details that need a distinct section, and make it a subheader of this.
 
 ## Testing
+
 - [ ] Insert manual, unit, and automated tests here
 
 ## Documentation
-- [ ] Add specific documentations and link their files (in the current branch
-  not main)
+
+- [ ] Add specific documentations and link their files (in the current branch not main)
 - Insert related info and documentation here
 
 ## References
-*We're using pull requests as a way to also document. So, put all the references
-and resources used to help make the changes in each PRs*
 
-- [ ] Add a log for this PR and link their files (in the current branch
-  not main)
+*We're using pull requests as a way to also document. So, put all the references and resources used to help make the changes in each PRs*
+
+- [ ] Add a log for this PR and link their files (in the current branch not main)
 - [ ] Insert how you solved the problem
 - [ ] Insert all references and help used to solve this problem
 
 ## TODO
 
-| Task |  Description | Date added | Date started | Date finished |
-|---|---|---|---|---|
+| Task | Description | Date added | Date started | Date finished |
+|------|-------------|------------|--------------|---------------|

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,10 @@ and resources used to help make the changes in each PRs*
 
 - [ ] Add a log for this PR and link their files (in the current branch
   not main)
+- [ ] Insert how you solved the problem
+- [ ] Insert all references and help used to solve this problem
 
-- Insert how you solved the problem
-- Insert all references and help used to solve this problem
+## TODO
+
+| Task |  Description | Date added | Date started | Date finished |
+|---|---|---|---|---|

--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -108,7 +108,7 @@ public abstract class BeatTest
             playerInput.Setup(i => i.ClaimOnStart(beat1)).Returns(true);
             var excellentInput = beat1.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Excellent, excellentInput);
-            playerInput.Setup(i => i.GetClaimingChannel()).Returns(beat1);
+            playerInput.Setup(i => i.GetClaimingChannel(It.IsAny<IBeat>())).Returns(beat1);
 
             var anticipating = beat2.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Anticipating, anticipating);

--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -64,6 +64,7 @@ public abstract class BeatTest
             var rhythmSimulator = new Mock<IRhythmSimulator>();
             var playerInput = new Mock<IRhythmInput>();
             playerInput.Setup(i => i.GetRhythmActionType()).Returns(RhythmActionType.Singular);
+            playerInput.Setup(i => i.GetSource()).Returns(InputSource.Player);
 
             // start: too far
             rhythmSimulator.Setup(r => r.GetCurrentSongTime())
@@ -98,6 +99,7 @@ public abstract class BeatTest
             var simulator = new Mock<IRhythmSimulator>();
             var playerInput = new Mock<IRhythmInput>();
             playerInput.Setup(i => i.GetRhythmActionType()).Returns(RhythmActionType.Singular);
+            playerInput.Setup(i => i.GetSource()).Returns(InputSource.Player);
 
             // within range of excellent with input
             simulator.Setup(r => r.GetCurrentSongTime())

--- a/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/BeatTest.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using Moq;
 using Xunit.Abstractions;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 using Yam.Core.Rhythm.Input;
 using Yam.Core.Test.Utility;
@@ -68,7 +69,7 @@ public abstract class BeatTest
 
             // start: too far
             rhythmSimulator.Setup(r => r.GetCurrentSongTime())
-                .Returns(beatTime - (Beat.DefaultTooEarlyRadius + Beat.FrameEpsilon));
+                .Returns(beatTime - (Beat.DefaultTooEarlyRadius + Globals.FrameEpsilon));
             var tooFar = beat.SimulateInput(rhythmSimulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Idle, tooFar);
 
@@ -79,7 +80,7 @@ public abstract class BeatTest
 
             // within range of excellent with input
             rhythmSimulator.Setup(r => r.GetCurrentSongTime())
-                .Returns(beatTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
+                .Returns(beatTime - Beat.DefaultExcellentRadius + Globals.FrameEpsilon);
             playerInput.Setup(i => i.ClaimOnStart(beat)).Returns(true);
             var excellentInput = beat.SimulateInput(rhythmSimulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Excellent, excellentInput);
@@ -103,7 +104,7 @@ public abstract class BeatTest
 
             // within range of excellent with input
             simulator.Setup(r => r.GetCurrentSongTime())
-                .Returns(beatTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
+                .Returns(beatTime - Beat.DefaultExcellentRadius + Globals.FrameEpsilon);
             playerInput.Setup(i => i.ClaimOnStart(beat1)).Returns(true);
             var excellentInput = beat1.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Excellent, excellentInput);
@@ -154,7 +155,7 @@ public abstract class BeatTest
 
             // start: too far
             simulator.Setup(r => r.GetCurrentSongTime())
-                .Returns(startTime - (Beat.DefaultTooEarlyRadius + Beat.FrameEpsilon));
+                .Returns(startTime - (Beat.DefaultTooEarlyRadius + Globals.FrameEpsilon));
             var tooFar = beat.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Idle, tooFar);
 
@@ -165,7 +166,7 @@ public abstract class BeatTest
 
             // within range of excellent with input
             simulator.Setup(r => r.GetCurrentSongTime())
-                .Returns(startTime - Beat.DefaultExcellentRadius + Beat.FrameEpsilon);
+                .Returns(startTime - Beat.DefaultExcellentRadius + Globals.FrameEpsilon);
             playerInput.Setup(i => i.ClaimOnStart(beat)).Returns(true);
             var holding = beat.SimulateInput(simulator.Object, playerInput.Object);
             Assert.Equal(BeatInputResult.Holding, holding);

--- a/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
@@ -55,11 +55,60 @@ public abstract class ChartTest
         }
     }
 
-    public class MultiHold
+    public class MultiHold(ITestOutputHelper xUnitLogger) : BaseTest(xUnitLogger)
     {
         [Fact]
         public void SimpleTwoHoldSimulation()
         {
+            var startTime = 10f;
+            var lowerBeatEndTime = 15f;
+            var upperBeatEndTime = lowerBeatEndTime + Beat.DefaultOkRadius;
+            var upperBeat = new BeatEntity([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(upperBeatEndTime, 1f)
+            ]);
+            var lowerBeat = new BeatEntity([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(lowerBeatEndTime, 1f)
+            ]);
+            var chart = BeatUtil.NewChart([upperBeat, lowerBeat], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input = new Mock<IRhythmInput>();
+
+            // channels are reorganized
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(0f);
+            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            Assert.True(chart.ChannelList[^2].TryToGetBeatForInput()?.CompareTimeUCoord(upperBeat));
+            Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
+
+            // at the exact time, let's do an idle
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            input.Setup(i => i.GetSource()).Returns(InputSource.Game);
+            chart.SimulateBeatInput(simulator.Object, input.Object);
+            Assert.True(chart.ChannelList[^2].TryToGetBeatForInput()?.CompareTimeUCoord(upperBeat));
+            Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
+
+            // try one input first
+            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            chart.SimulateBeatInput(simulator.Object, input.Object);
+            Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput());
+            Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
+
+            // try second input
+            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            chart.SimulateBeatInput(simulator.Object, input.Object);
+            Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
+            Assert.Null(chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+            
+            // todo(turnip): check if input received in a possible interface is not the input we put
+            // see ingestedInput in Chart.SimulateBeatInputIn
         }
 
         // todo(turnip): hold + tap (released)

--- a/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
@@ -1,0 +1,78 @@
+using JetBrains.Annotations;
+using Moq;
+using Xunit.Abstractions;
+using Yam.Core.Rhythm.Chart;
+using Yam.Core.Rhythm.Input;
+using Yam.Core.Test.Utility;
+
+namespace Yam.Core.Test.Rhythm.Chart;
+
+[TestSubject(typeof(Core.Rhythm.Chart.Chart))]
+public abstract class ChartTest
+{
+    public class SingleBeat(ITestOutputHelper xUnitLogger) : BaseTest(xUnitLogger)
+    {
+        [Fact]
+        public void SimultaneousSingleBeat()
+        {
+            var chart = BeatUtil.NewChart([
+                new(10f) { UCoord = 1f },
+                new(10f) { UCoord = 2f }
+            ], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input = new Mock<IRhythmInput>();
+
+            // channels are reorganized
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(0f);
+            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            Assert.Equal(10f, chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
+            Assert.Equal(10f, chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+
+            // at the exact time, let's do an idle
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(10f);
+            input.Setup(i => i.GetSource()).Returns(InputSource.Game);
+            chart.SimulateBeatInput(simulator.Object, input.Object);
+            Assert.Equal(10f, chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
+            Assert.Equal(10f, chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+
+            // try one input first
+            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) =>
+                {
+                    input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false);
+                });
+            chart.SimulateBeatInput(simulator.Object, input.Object);
+            Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
+            Assert.Equal(10f, chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+
+            // try second input
+            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) =>
+                {
+                    input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false);
+                });
+            chart.SimulateBeatInput(simulator.Object, input.Object);
+            Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
+            Assert.Null(chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+        }
+    }
+
+    public class MultiHold
+    {
+        [Fact]
+        public void SimpleTwoHoldSimulation()
+        {
+        }
+
+        // todo(turnip): hold + tap (released)
+
+        // todo(turnip): hold + tap (unreleased)
+
+        // todo(turnip): hold + slide
+    }
+}

--- a/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
@@ -62,7 +62,7 @@ public abstract class ChartTest
         {
             var startTime = 10f;
             var lowerBeatEndTime = 15f;
-            var upperBeatEndTime = lowerBeatEndTime + Beat.DefaultOkRadius;
+            var upperBeatEndTime = lowerBeatEndTime + Beat.DefaultGoodRadius;
             var upperBeat = new BeatEntity([
                 new BeatEntity(startTime, 1f),
                 new BeatEntity(upperBeatEndTime, 1f)
@@ -74,41 +74,51 @@ public abstract class ChartTest
             var chart = BeatUtil.NewChart([upperBeat, lowerBeat], XUnitLogger);
 
             var simulator = new Mock<IRhythmSimulator>();
-            var input = new Mock<IRhythmInput>();
+            var input1 = new Mock<IRhythmInput>();
+            var input2 = new Mock<IRhythmInput>();
 
             // channels are reorganized
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(0f);
-            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            var upperBeatModel = chart.ChannelList[^2].TryToGetBeatForInput();
+            var lowerBeatModel = chart.ChannelList.Last().TryToGetBeatForInput();
+            Assert.NotNull(upperBeatModel);
+            Assert.NotNull(lowerBeatModel);
             Assert.True(chart.ChannelList[^2].TryToGetBeatForInput()?.CompareTimeUCoord(upperBeat));
             Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
 
             // at the exact time, let's do an idle
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
-            input.Setup(i => i.GetSource()).Returns(InputSource.Game);
-            chart.SimulateBeatInput(simulator.Object, input.Object);
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Game);
+            chart.SimulateBeatInput(simulator.Object, input1.Object);
             Assert.True(chart.ChannelList[^2].TryToGetBeatForInput()?.CompareTimeUCoord(upperBeat));
             Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
 
             // try one input first
-            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
-            input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
                 .Returns(true)
-                .Callback<IBeat>((beat) => { input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
-            chart.SimulateBeatInput(simulator.Object, input.Object);
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            chart.SimulateBeatInput(simulator.Object, input1.Object);
             Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput());
             Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
 
             // try second input
-            input.Setup(i => i.GetSource()).Returns(InputSource.Player);
-            input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+            input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input2.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
                 .Returns(true)
-                .Callback<IBeat>((beat) => { input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
-            chart.SimulateBeatInput(simulator.Object, input.Object);
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            chart.SimulateBeatInput(simulator.Object, input2.Object);
             Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
             Assert.Null(chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
             
             // todo(turnip): check if input received in a possible interface is not the input we put
             // see ingestedInput in Chart.SimulateBeatInputIn
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(lowerBeatEndTime);
+            Assert.Equal(BeatInputResult.Holding, upperBeatModel!.SimulateHoldingIdleBeat());
+            Assert.Equal(BeatInputResult.Holding, lowerBeatModel!.SimulateHoldingIdleBeat());
+            
+            // now we let multiholdinput do its job. see multiholdinputtest
         }
         
         // todo(turnip): second input not registered within visual time

--- a/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
@@ -15,10 +15,9 @@ public abstract class ChartTest
         [Fact]
         public void SimultaneousSingleBeat()
         {
-            var chart = BeatUtil.NewChart([
-                new(10f) { UCoord = 1f },
-                new(10f) { UCoord = 2f }
-            ], XUnitLogger);
+            var upperBeat = new BeatEntity(10f, 1f);
+            var lowerBeat = new BeatEntity(10f, 2f);
+            var chart = BeatUtil.NewChart([upperBeat, lowerBeat], XUnitLogger);
 
             var simulator = new Mock<IRhythmSimulator>();
             var input = new Mock<IRhythmInput>();
@@ -26,36 +25,30 @@ public abstract class ChartTest
             // channels are reorganized
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(0f);
             input.Setup(i => i.GetSource()).Returns(InputSource.Player);
-            Assert.Equal(10f, chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
-            Assert.Equal(10f, chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+            Assert.True(chart.ChannelList[^2].TryToGetBeatForInput()?.CompareTimeUCoord(upperBeat));
+            Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
 
             // at the exact time, let's do an idle
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(10f);
             input.Setup(i => i.GetSource()).Returns(InputSource.Game);
             chart.SimulateBeatInput(simulator.Object, input.Object);
-            Assert.Equal(10f, chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
-            Assert.Equal(10f, chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+            Assert.True(chart.ChannelList[^2].TryToGetBeatForInput()?.CompareTimeUCoord(upperBeat));
+            Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
 
             // try one input first
             input.Setup(i => i.GetSource()).Returns(InputSource.Player);
             input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
                 .Returns(true)
-                .Callback<IBeat>((beat) =>
-                {
-                    input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false);
-                });
+                .Callback<IBeat>((beat) => { input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
             chart.SimulateBeatInput(simulator.Object, input.Object);
             Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
-            Assert.Equal(10f, chart.ChannelList.Last().TryToGetBeatForInput()?.Time);
+            Assert.True(chart.ChannelList.Last().TryToGetBeatForInput()?.CompareTimeUCoord(lowerBeat));
 
             // try second input
             input.Setup(i => i.GetSource()).Returns(InputSource.Player);
             input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
                 .Returns(true)
-                .Callback<IBeat>((beat) =>
-                {
-                    input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false);
-                });
+                .Callback<IBeat>((beat) => { input.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
             chart.SimulateBeatInput(simulator.Object, input.Object);
             Assert.Null(chart.ChannelList[^2].TryToGetBeatForInput()?.Time);
             Assert.Null(chart.ChannelList.Last().TryToGetBeatForInput()?.Time);

--- a/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
+++ b/Yam.Core.Test/Rhythm/Chart/ChartTest.cs
@@ -110,6 +110,8 @@ public abstract class ChartTest
             // todo(turnip): check if input received in a possible interface is not the input we put
             // see ingestedInput in Chart.SimulateBeatInputIn
         }
+        
+        // todo(turnip): second input not registered within visual time
 
         // todo(turnip): hold + tap (released)
 

--- a/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/KeyboardSingularInputTest.cs
@@ -20,13 +20,13 @@ public abstract class KeyboardSingularInputTest
             // you cannot claim an unpressed button
             var beat = new Mock<IBeat>();
             Assert.False(input.ClaimOnStart(beat.Object));
-            Assert.Null(input.GetClaimingChannel());
+            Assert.Null(input.GetClaimingChannel(beat.Object));
 
             // you can claim a button only on start, for now
             input.Activate();
             Assert.Equal(SingularInputState.Started, input.GetState());
             Assert.True(input.ClaimOnStart(beat.Object));
-            Assert.Equal(beat.Object, input.GetClaimingChannel());
+            Assert.Equal(beat.Object, input.GetClaimingChannel(beat.Object));
 
             // you cannot claim a button that's already claimed
             var differentBeat = new Mock<IBeat>();
@@ -47,7 +47,7 @@ public abstract class KeyboardSingularInputTest
             // you cannot claim an unpressed button
             var beat = new Mock<IBeat>();
             Assert.False(input.ClaimOnStart(beat.Object));
-            Assert.Null(input.GetClaimingChannel());
+            Assert.Null(input.GetClaimingChannel(beat.Object));
 
             // you can claim a button only on start, for now
             input.Activate();
@@ -57,7 +57,7 @@ public abstract class KeyboardSingularInputTest
             input.Activate();
             Assert.Equal(SingularInputState.Held, input.GetState());
             Assert.False(input.ClaimOnStart(beat.Object));
-            Assert.Null(input.GetClaimingChannel());
+            Assert.Null(input.GetClaimingChannel(beat.Object));
         }
         
         [Fact]
@@ -68,20 +68,20 @@ public abstract class KeyboardSingularInputTest
             // you cannot claim an unpressed button
             var beat = new Mock<IBeat>();
             Assert.False(input.ClaimOnStart(beat.Object));
-            Assert.Null(input.GetClaimingChannel());
+            Assert.Null(input.GetClaimingChannel(beat.Object));
 
             // you can claim a button only on start, for now
             input.Activate();
             Assert.Equal(SingularInputState.Started, input.GetState());
             Assert.True(input.ClaimOnStart(beat.Object));
-            Assert.Equal(beat.Object, input.GetClaimingChannel());
+            Assert.Equal(beat.Object, input.GetClaimingChannel(beat.Object));
 
             // hold status
             input.Activate();
             Assert.Equal(SingularInputState.Held, input.GetState());
             var differentBeat = new Mock<IBeat>();
             Assert.False(input.ClaimOnStart(differentBeat.Object));
-            Assert.Equal(beat.Object, input.GetClaimingChannel());
+            Assert.Equal(beat.Object, input.GetClaimingChannel(beat.Object));
 
             // on release, all claims are released also, and the claimer will be informed
             // note: that we have to be very careful with this

--- a/Yam.Core.Test/Rhythm/Input/MultiHoldInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/MultiHoldInputTest.cs
@@ -1,0 +1,84 @@
+using JetBrains.Annotations;
+using Moq;
+using Xunit.Abstractions;
+using Yam.Core.Rhythm.Chart;
+using Yam.Core.Rhythm.Input;
+using Yam.Core.Test.Utility;
+
+namespace Yam.Core.Test.Rhythm.Input;
+
+[TestSubject(typeof(MultiHoldInput))]
+public abstract class MultiHoldInputTest
+{
+    
+    public class MultiHold(ITestOutputHelper xUnitLogger) : BaseTest(xUnitLogger)
+    {
+        [Fact]
+        public void SimpleTwoHoldSimulation()
+        {
+            var startTime = 10f;
+            var earlierEnd = 15f;
+            var laterEnd = earlierEnd + Beat.DefaultGoodRadius;
+            var laterBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(laterEnd, 1f)
+            ], XUnitLogger);
+            var earlierBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(earlierEnd, 1f)
+            ], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input1 = new Mock<IRhythmInput>();
+            var input2 = new Mock<IRhythmInput>();
+            
+            // initialize simulator
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            var multiHoldInput = new MultiHoldInput(simulator.Object, input1.Object);
+            multiHoldInput.Logger.XUnitLogger = XUnitLogger;
+
+            // try one input first
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, laterBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
+            
+            // try second input
+            multiHoldInput.AddInput(input2.Object);
+            input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input2.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, earlierBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            
+            // check results
+            Assert.Equal(BeatInputResult.Holding, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
+            
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(earlierEnd);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Excellent, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
+            
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(earlierEnd);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Excellent, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Ok, laterBeat.HoldReleaseResult);
+        }
+        
+        // todo(turnip): second input not registered within visual time
+
+        // todo(turnip): hold + tap (released)
+
+        // todo(turnip): hold + tap (unreleased)
+
+        // todo(turnip): hold + slide
+    }
+}

--- a/Yam.Core.Test/Rhythm/Input/MultiHoldInputTest.cs
+++ b/Yam.Core.Test/Rhythm/Input/MultiHoldInputTest.cs
@@ -10,7 +10,6 @@ namespace Yam.Core.Test.Rhythm.Input;
 [TestSubject(typeof(MultiHoldInput))]
 public abstract class MultiHoldInputTest
 {
-    
     public class MultiHold(ITestOutputHelper xUnitLogger) : BaseTest(xUnitLogger)
     {
         [Fact]
@@ -31,7 +30,7 @@ public abstract class MultiHoldInputTest
             var simulator = new Mock<IRhythmSimulator>();
             var input1 = new Mock<IRhythmInput>();
             var input2 = new Mock<IRhythmInput>();
-            
+
             // initialize simulator
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
             var multiHoldInput = new MultiHoldInput(simulator.Object, input1.Object);
@@ -45,7 +44,7 @@ public abstract class MultiHoldInputTest
             Assert.Equal(BeatInputResult.Holding, laterBeat.SimulateInput(simulator.Object, multiHoldInput));
             input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
             input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
-            
+
             // try second input
             multiHoldInput.AddInput(input2.Object);
             input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
@@ -55,29 +54,262 @@ public abstract class MultiHoldInputTest
             Assert.Equal(BeatInputResult.Holding, earlierBeat.SimulateInput(simulator.Object, multiHoldInput));
             input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
             input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
-            
+
             // check results
             Assert.Equal(BeatInputResult.Holding, earlierBeat.HoldReleaseResult);
             Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
-            
+
             // first, let's release during earlierBeat
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(earlierEnd);
             multiHoldInput.OnInputRelease();
             Assert.Equal(BeatInputResult.Excellent, earlierBeat.HoldReleaseResult);
             Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
-            
+
             // first, let's release during earlierBeat
             simulator.Setup(s => s.GetCurrentSongTime()).Returns(earlierEnd);
             multiHoldInput.OnInputRelease();
             Assert.Equal(BeatInputResult.Excellent, earlierBeat.HoldReleaseResult);
             Assert.Equal(BeatInputResult.Ok, laterBeat.HoldReleaseResult);
         }
+
+
+        [Fact]
+        public void FailVisualTimeSimulation()
+        {
+            var startTime = 10f;
+            var earlierEnd = 15f;
+            var laterEnd = earlierEnd + Beat.DefaultGoodRadius;
+            var laterBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(laterEnd, 1f)
+            ], XUnitLogger);
+            var earlierBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(earlierEnd, 1f)
+            ], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input1 = new Mock<IRhythmInput>();
+            var input2 = new Mock<IRhythmInput>();
+
+            // initialize simulator
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            var multiHoldInput = new MultiHoldInput(simulator.Object, input1.Object);
+            multiHoldInput.Logger.XUnitLogger = XUnitLogger;
+
+            // try one input first
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, laterBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
+
+            // try second input
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime + MultiHoldInput.VisualEpsilon);
+            Assert.False(multiHoldInput.AddInput(input2.Object));
+            input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input2.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Anticipating, earlierBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
+
+            // check results
+            Assert.Equal(BeatInputResult.Idle, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
+
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(earlierEnd);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Idle, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Ok, laterBeat.HoldReleaseResult);
+        }
+
+        [Fact]
+        public void FailRelease()
+        {
+            var startTime = 10f;
+            var earlierEnd = 15f;
+            var laterEnd = earlierEnd + Beat.DefaultGoodRadius;
+            var laterBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(laterEnd, 1f)
+            ], XUnitLogger);
+            var earlierBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(earlierEnd, 1f)
+            ], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input1 = new Mock<IRhythmInput>();
+            var input2 = new Mock<IRhythmInput>();
+
+            // initialize simulator
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            var multiHoldInput = new MultiHoldInput(simulator.Object, input1.Object);
+            multiHoldInput.Logger.XUnitLogger = XUnitLogger;
+
+            // try one input first
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, laterBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
+
+            // try second input
+            multiHoldInput.AddInput(input2.Object);
+            input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input2.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, earlierBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+
+            // check results
+            earlierBeat.SimulateHoldingIdleBeat();
+            laterBeat.SimulateHoldingIdleBeat();
+            Assert.Equal(BeatInputResult.Holding, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
+
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(earlierEnd + Beat.DefaultOkRadius);
+            earlierBeat.SimulateHoldingIdleBeat();
+            laterBeat.SimulateHoldingIdleBeat();
+            Assert.Equal(BeatInputResult.Miss, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Holding, laterBeat.HoldReleaseResult);
+
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(laterEnd + Beat.DefaultOkRadius);
+            earlierBeat.SimulateHoldingIdleBeat();
+            laterBeat.SimulateHoldingIdleBeat();
+            Assert.Equal(BeatInputResult.Miss, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Miss, laterBeat.HoldReleaseResult);
+
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Miss, earlierBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Miss, laterBeat.HoldReleaseResult);
+        }
+
+        [Fact]
+        public void HoldAndTapLateReleaseSuccess()
+        {
+            var startTime = 10f;
+            var endTime = 15f;
+            var tapBeat = BeatUtil.NewSingleBeat(new BeatEntity(startTime, 1f), XUnitLogger);
+            var holdBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(endTime, 1f)
+            ], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input1 = new Mock<IRhythmInput>();
+            var input2 = new Mock<IRhythmInput>();
+
+            // initialize simulator
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            var multiHoldInput = new MultiHoldInput(simulator.Object, input1.Object);
+            multiHoldInput.Logger.XUnitLogger = XUnitLogger;
+
+            // try one input first
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Excellent, tapBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
+
+            // try second input
+            multiHoldInput.AddInput(input2.Object);
+            input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input2.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, holdBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+
+            // check results
+            Assert.Equal(BeatInputResult.Holding, holdBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Idle, tapBeat.HoldReleaseResult);
+
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(endTime);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Excellent, holdBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Idle, tapBeat.HoldReleaseResult);
+
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(endTime);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Excellent, holdBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Idle, tapBeat.HoldReleaseResult);
+        }
         
-        // todo(turnip): second input not registered within visual time
+        [Fact]
+        public void HoldAndTapEarlyReleaseSuccess()
+        {
+            var startTime = 10f;
+            var endTime = 15f;
+            var tapBeat = BeatUtil.NewSingleBeat(new BeatEntity(startTime, 1f), XUnitLogger);
+            var holdBeat = BeatUtil.NewHoldBeat([
+                new BeatEntity(startTime, 1f),
+                new BeatEntity(endTime, 1f)
+            ], XUnitLogger);
+
+            var simulator = new Mock<IRhythmSimulator>();
+            var input1 = new Mock<IRhythmInput>();
+            var input2 = new Mock<IRhythmInput>();
+
+            // initialize simulator
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            var multiHoldInput = new MultiHoldInput(simulator.Object, input1.Object);
+            multiHoldInput.Logger.XUnitLogger = XUnitLogger;
+
+            // try one input first
+            input1.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Excellent, tapBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Never);
+
+            // try second input
+            multiHoldInput.AddInput(input2.Object);
+            input2.Setup(i => i.GetSource()).Returns(InputSource.Player);
+            input2.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>()))
+                .Returns(true)
+                .Callback<IBeat>((beat) => { input1.Setup(i => i.ClaimOnStart(It.IsAny<IBeat>())).Returns(false); });
+            Assert.Equal(BeatInputResult.Holding, holdBeat.SimulateInput(simulator.Object, multiHoldInput));
+            input1.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+            input2.Verify(i => i.ClaimOnStart(multiHoldInput), Times.Once);
+
+            // check results
+            Assert.Equal(BeatInputResult.Holding, holdBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Idle, tapBeat.HoldReleaseResult);
+
+            // first, let's release for tap
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(startTime);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Holding, holdBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Idle, tapBeat.HoldReleaseResult);
+
+            // first, let's release during earlierBeat
+            simulator.Setup(s => s.GetCurrentSongTime()).Returns(endTime);
+            multiHoldInput.OnInputRelease();
+            Assert.Equal(BeatInputResult.Excellent, holdBeat.HoldReleaseResult);
+            Assert.Equal(BeatInputResult.Idle, tapBeat.HoldReleaseResult);
+        }
 
         // todo(turnip): hold + tap (released)
 
-        // todo(turnip): hold + tap (unreleased)
 
         // todo(turnip): hold + slide
     }

--- a/Yam.Core.Test/Utility/BeatUtil.cs
+++ b/Yam.Core.Test/Utility/BeatUtil.cs
@@ -24,12 +24,22 @@ public static class BeatUtil
     {
         return Beat.FromEntity(beatEntity, Beat.DefaultRelativeReactionWindow, xUnitLogger);
     }
-    
+
     public static Beat NewHoldBeat(List<BeatEntity> beatEntityList, ITestOutputHelper xUnitLogger)
     {
         Debug.Assert(beatEntityList.Count > 0);
         var baseBeat = beatEntityList[0].ShallowClone();
         baseBeat.BeatList = beatEntityList;
-        return Beat.FromEntity(baseBeat, Beat.DefaultRelativeReactionWindow,xUnitLogger);
+        return Beat.FromEntity(baseBeat, Beat.DefaultRelativeReactionWindow, xUnitLogger);
+    }
+
+
+    public static Chart NewChart(List<BeatEntity> beatEntityList, ITestOutputHelper xUnitLogger)
+    {
+        Debug.Assert(beatEntityList.Count > 0);
+        return Chart.FromEntity(
+            new ChartEntity() { BeatList = beatEntityList },
+            Beat.DefaultRelativeReactionWindow,
+            xUnitLogger);
     }
 }

--- a/Yam.Core/Common/GameLogger.cs
+++ b/Yam.Core/Common/GameLogger.cs
@@ -16,11 +16,6 @@ public class GameLogger
     {
         if (XUnitLogger != null)
         {
-            foreach (var key in Environment.GetEnvironmentVariables().Keys)
-            {
-                XUnitLogger.WriteLine($"{key}: {Environment.GetEnvironmentVariables()[key]}");
-            }
-
             XUnitLogger.WriteLine(what.Join(""));
         }
         else if (IsGodot)

--- a/Yam.Core/Common/GameLogger.cs
+++ b/Yam.Core/Common/GameLogger.cs
@@ -1,36 +1,51 @@
+using System;
 using Godot;
 using Xunit.Abstractions;
+using Environment = System.Environment;
 
 namespace Yam.Core.Common;
 
-// todo(turnip): improve GameLogger by detecting that we're being run in xUnit
-// and ignore any calls to Godot. Or check if Godot's GD global function specific
-// to Print is available for use
 public class GameLogger
 {
+    private static readonly bool IsGodot = Environment.GetEnvironmentVariable("GODOT_EDITOR_CUSTOM_FEATURES") != null;
+    private static readonly bool IsLocalTest = Environment.GetEnvironmentVariable("RESHARPER_TESTRUNNER") != null;
+
     public ITestOutputHelper? XUnitLogger;
 
     public void Print(params string[] what)
     {
         if (XUnitLogger != null)
         {
+            foreach (var key in Environment.GetEnvironmentVariables().Keys)
+            {
+                XUnitLogger.WriteLine($"{key}: {Environment.GetEnvironmentVariables()[key]}");
+            }
+
             XUnitLogger.WriteLine(what.Join(""));
         }
-        else
+        else if (IsGodot)
         {
             GD.Print(what);
         }
+        else if (IsLocalTest && XUnitLogger == null)
+        {
+            throw new Exception("Missing XUnitLogger");
+        }
     }
-    
+
     public void PrintErr(string what)
     {
         if (XUnitLogger != null)
         {
             XUnitLogger.WriteLine($"Godot.PrintErr: {what}");
         }
-        else
+        else if (IsGodot)
         {
             GD.PrintErr(what);
+        }
+        else if (IsLocalTest && XUnitLogger == null)
+        {
+            throw new Exception("Missing XUnitLogger");
         }
     }
 }

--- a/Yam.Core/Common/Globals.cs
+++ b/Yam.Core/Common/Globals.cs
@@ -1,0 +1,6 @@
+namespace Yam.Core.Common;
+
+public static class Globals
+{
+    public const float FrameEpsilon = 1f / 60f;
+}

--- a/Yam.Core/Rhythm/Chart/Beat.cs
+++ b/Yam.Core/Rhythm/Chart/Beat.cs
@@ -17,7 +17,6 @@ public class Beat : TimeUCoordVector, IBeat
     public static readonly float DefaultOkRadius = 0.75f;
     public static readonly float DefaultGoodRadius = 0.5f;
     public static readonly float DefaultExcellentRadius = 0.2f;
-    public static readonly float FrameEpsilon = 1f / 60f;
 
     // todo(turnip): NOW
     public static readonly List<ReactionWindow> DefaultRelativeReactionWindow = new()

--- a/Yam.Core/Rhythm/Chart/Beat.cs
+++ b/Yam.Core/Rhythm/Chart/Beat.cs
@@ -334,7 +334,7 @@ public class Beat : TimeUCoordVector, IBeat
             return BeatInputResult.Anticipating;
         }
 
-        if (playerInput.GetClaimingChannel() == null && playerInput.ClaimOnStart(this))
+        if (playerInput.GetClaimingChannel(this) == null && playerInput.ClaimOnStart(this))
         {
             foreach (var reactionWindow in _reactionWindowList.Where(reactionWindow =>
                          reactionWindow.Range.X < currentTime && currentTime < reactionWindow.Range.Y))

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -62,8 +62,8 @@ public class BeatChannel : List<Beat>
         {
             case BeatInputResult.Idle:
             case BeatInputResult.Anticipating:
-            case BeatInputResult.Holding:
                 break;
+            case BeatInputResult.Holding:
             case BeatInputResult.Done:
             case BeatInputResult.TooEarly:
             case BeatInputResult.Miss:

--- a/Yam.Core/Rhythm/Chart/BeatChannel.cs
+++ b/Yam.Core/Rhythm/Chart/BeatChannel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Xunit.Abstractions;
 using Yam.Core.Common;
 using Yam.Core.Rhythm.Input;
 
@@ -11,6 +12,14 @@ public class BeatChannel : List<Beat>
     
     private int _currentVisualizationIndex;
     private int _currentInputIndex;
+
+    public BeatChannel(ITestOutputHelper? xUnitLogger)
+    {
+        if (xUnitLogger != null)
+        {
+            Logger.XUnitLogger = xUnitLogger;
+        }
+    }
 
     // todo: give current beats to visualize given current time and time frame to visualize
 
@@ -39,7 +48,7 @@ public class BeatChannel : List<Beat>
         return null;
     }
 
-    private Beat? TryToGetBeatForInput()
+    public Beat? TryToGetBeatForInput()
     {
         return _currentInputIndex >= Count ? null : this[_currentInputIndex];
     }

--- a/Yam.Core/Rhythm/Chart/BeatEntity.cs
+++ b/Yam.Core/Rhythm/Chart/BeatEntity.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Yam.Core.Rhythm.Chart;
 
@@ -21,6 +22,17 @@ public class BeatEntity : TimeUCoordVector
     {
         Time = time;
         UCoord = uCoord;
+    }
+    
+    public BeatEntity(List<BeatEntity> tickList)
+    {
+        Debug.Assert(tickList.Count > 0);
+        var initialTick = tickList[0];
+        Time = initialTick.Time;
+        UCoord = initialTick.UCoord;
+        PIn = initialTick.PIn?.Clone();
+        POut = initialTick.POut?.Clone();
+        tickList.ForEach(t => BeatList.Add(t));
     }
 
     public TimeUCoordVector? PIn { get; set; }

--- a/Yam.Core/Rhythm/Chart/BeatEntity.cs
+++ b/Yam.Core/Rhythm/Chart/BeatEntity.cs
@@ -16,6 +16,12 @@ public class BeatEntity : TimeUCoordVector
     {
         Time = time;
     }
+    
+    public BeatEntity(float time, float uCoord)
+    {
+        Time = time;
+        UCoord = uCoord;
+    }
 
     public TimeUCoordVector? PIn { get; set; }
     public TimeUCoordVector? POut { get; set; }
@@ -27,11 +33,13 @@ public class BeatEntity : TimeUCoordVector
     /// <returns>BeatEntity</returns>
     public BeatEntity ShallowClone()
     {
-        var newBeat = new BeatEntity();
-        newBeat.Time = Time;
-        newBeat.UCoord = UCoord;
-        newBeat.PIn = PIn?.Clone();
-        newBeat.POut = POut?.Clone();
+        var newBeat = new BeatEntity
+        {
+            Time = Time,
+            UCoord = UCoord,
+            PIn = PIn?.Clone(),
+            POut = POut?.Clone()
+        };
         return newBeat;
     }
 }

--- a/Yam.Core/Rhythm/Chart/BeatInputResultUtil.cs
+++ b/Yam.Core/Rhythm/Chart/BeatInputResultUtil.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Yam.Core.Rhythm.Chart;
+
+public static class BeatInputResultUtil
+{
+    public static int WorstScore = -100;
+
+    public static int GetScore(BeatInputResult? result)
+    {
+        return result switch
+        {
+            BeatInputResult.Idle
+                or BeatInputResult.Ignore
+                or BeatInputResult.Done
+                or BeatInputResult.Anticipating
+                or BeatInputResult.Holding
+                or null => 0,
+            BeatInputResult.TooEarly or BeatInputResult.Miss => -1,
+            BeatInputResult.Bad => -2,
+            BeatInputResult.Ok => 1,
+            BeatInputResult.Good => 2,
+            BeatInputResult.Excellent => 3,
+            _ => throw new ArgumentOutOfRangeException(nameof(result), result, null)
+        };
+    }
+}

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -105,11 +105,14 @@ public class Chart
             && realInput.GetSource() == InputSource.Player
             && !realInput.IsValidDirection())
         {
-            _multiHoldInput.AddInput(realInput);
+            if (_multiHoldInput.AddInput(realInput))
+            {
+                ingestedInput = _multiHoldInput;
+            }
         }
         else if (_multiHoldInput != null)
         {
-            ingestedInput = _multiHoldInput;
+            // do nothing
         }
         else if (realInput.GetSource() == InputSource.Player)
         {

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -91,21 +91,24 @@ public class Chart
 
     private MultiHoldInput? _multiHoldInput;
 
-    public void SimulateBeatInput(IRhythmSimulator rhythmSimulator, IRhythmInput input)
+    public void SimulateBeatInput(IRhythmSimulator rhythmSimulator, IRhythmInput realInput)
     {
-        if (input.GetSource() == InputSource.Unknown)
+        if (realInput.GetSource() == InputSource.Unknown)
         {
             return;
         }
 
-        if (_multiHoldInput != null && input.GetSource() == InputSource.Player)
+        // ingestedInput will be overriden under certain conditions below
+        var ingestedInput = realInput;
+        
+        if (_multiHoldInput != null && realInput.GetSource() == InputSource.Player)
         {
         }
         else if (_multiHoldInput != null)
         {
             // do nothing
         }
-        else if (input.GetSource() == InputSource.Player)
+        else if (realInput.GetSource() == InputSource.Player)
         {
             // the sorting and input grouping is only important for input from player
             var shouldSort = false;
@@ -166,6 +169,6 @@ public class Chart
             // todo(turnip): check if at least one hold is in the list
         }
 
-        ChannelList.ForEach(c => c.SimulateBeatInput(rhythmSimulator, input));
+        ChannelList.ForEach(c => c.SimulateBeatInput(rhythmSimulator, ingestedInput));
     }
 }

--- a/Yam.Core/Rhythm/Chart/Chart.cs
+++ b/Yam.Core/Rhythm/Chart/Chart.cs
@@ -101,12 +101,15 @@ public class Chart
         // ingestedInput will be overriden under certain conditions below
         var ingestedInput = realInput;
         
-        if (_multiHoldInput != null && realInput.GetSource() == InputSource.Player)
+        if (_multiHoldInput != null 
+            && realInput.GetSource() == InputSource.Player
+            && !realInput.IsValidDirection())
         {
+            _multiHoldInput.AddInput(realInput);
         }
         else if (_multiHoldInput != null)
         {
-            // do nothing
+            ingestedInput = _multiHoldInput;
         }
         else if (realInput.GetSource() == InputSource.Player)
         {
@@ -164,11 +167,18 @@ public class Chart
             {
                 // todo: create fake input??? if one is a hold
                 Logger.Print($"Detected equal inputs: {similarChannelList.Count}");
+                _multiHoldInput = new MultiHoldInput(rhythmSimulator, realInput);
+                ingestedInput = _multiHoldInput;
             }
 
             // todo(turnip): check if at least one hold is in the list
         }
 
         ChannelList.ForEach(c => c.SimulateBeatInput(rhythmSimulator, ingestedInput));
+
+        if (_multiHoldInput != null && _multiHoldInput.IsStillAcceptingInputs())
+        {
+            _multiHoldInput = null;
+        }
     }
 }

--- a/Yam.Core/Rhythm/Chart/IBeat.cs
+++ b/Yam.Core/Rhythm/Chart/IBeat.cs
@@ -5,4 +5,5 @@ namespace Yam.Core.Rhythm.Chart;
 public interface IBeat: IRhythmInputListener
 {
     void SetVisualizer(IBeatVisualizer visualizer);
+    BeatInputResult OnSimulateInputRelease();
 }

--- a/Yam.Core/Rhythm/Chart/TimeUCoordVector.cs
+++ b/Yam.Core/Rhythm/Chart/TimeUCoordVector.cs
@@ -1,4 +1,6 @@
+using System;
 using Godot;
+using Yam.Core.Common;
 
 namespace Yam.Core.Rhythm.Chart;
 
@@ -23,5 +25,11 @@ public class TimeUCoordVector
             Time = Time,
             UCoord = UCoord
         };
+    }
+
+    public bool CompareTimeUCoord(TimeUCoordVector other)
+    {
+        return Math.Abs(Time - other.Time) < Globals.FrameEpsilon &&
+               Math.Abs(UCoord - other.UCoord) < Globals.FrameEpsilon;
     }
 }

--- a/Yam.Core/Rhythm/Input/IRhythmInput.cs
+++ b/Yam.Core/Rhythm/Input/IRhythmInput.cs
@@ -16,7 +16,7 @@ public interface IRhythmInput
 
     public Vector2 GetDirection();
     public string GetInputCode();
-    public IBeat? GetClaimingChannel();
+    public IBeat? GetClaimingChannel(IBeat contextualBeat);
 
     /// <summary>
     /// Returns true if successfully claimed channel. False if another channel claimed this input

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -38,7 +38,7 @@ public class KeyboardSingularInput : ISingularInput
         return _keyCode;
     }
 
-    public IBeat? GetClaimingChannel() => _claimingBeat;
+    public IBeat? GetClaimingChannel(IBeat contextualBeat) => _claimingBeat;
 
     public bool ClaimOnStart(IBeat claimingBeat)
     {

--- a/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
+++ b/Yam.Core/Rhythm/Input/KeyboardSingularInput.cs
@@ -58,7 +58,7 @@ public class KeyboardSingularInput : ISingularInput
 
     public InputSource GetSource()
     {
-        return InputSource.Game;
+        return InputSource.Player;
     }
 
     public RhythmActionType GetRhythmActionType()

--- a/Yam.Core/Rhythm/Input/MultiHoldInput.cs
+++ b/Yam.Core/Rhythm/Input/MultiHoldInput.cs
@@ -1,74 +1,119 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Godot;
+using Godot.NativeInterop;
+using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 
 namespace Yam.Core.Rhythm.Input;
 
 public class MultiHoldInput : IRhythmInput
 {
-    // Inspired by the Null Object Pattern
-    public static readonly MultiHoldInput GameInput = new(InputSource.Game);
-    public static readonly MultiHoldInput UnknownInput = new(InputSource.Unknown);
+    public const float VisualEpsilon = 0.25f;
 
-    private readonly InputSource _source;
+    private readonly IRhythmSimulator _simulator;
+    private readonly List<IRhythmInput> _incativeList = [];
+    private readonly List<IRhythmInput> _activeList = [];
+    private readonly float _startingTime;
 
-    private MultiHoldInput(InputSource source)
+    public MultiHoldInput(IRhythmSimulator rhythmSimulator, IRhythmInput firstInput)
     {
-        _source = source;
+        _simulator = rhythmSimulator;
+        _incativeList.Add(firstInput);
+
+        _startingTime = _simulator.GetCurrentSongTime();
     }
 
     public bool IsValidDirection()
     {
-        throw new NotImplementedException();
+        return false;
     }
 
     public bool IsDirectionSensitive()
     {
-        throw new NotImplementedException();
+        return false;
     }
 
     public Vector2 GetDirection()
     {
-        throw new NotImplementedException();
+        return Vector2.Zero;
     }
 
     public string GetInputCode()
     {
-        throw new NotImplementedException();
+        // todo(turnip): do we need to know?
+        return "multi";
     }
 
-    public IBeat? GetClaimingChannel()
+    public IBeat? GetClaimingChannel(IBeat contextualBeat)
     {
-        throw new NotImplementedException();
+        // todo: we need to make unit test here
+        if (_activeList.Exists(i => i.GetClaimingChannel(contextualBeat) == contextualBeat))
+        {
+            return contextualBeat;
+        }
+
+        return _activeList.Count > 0
+            ? _activeList[0].GetClaimingChannel(contextualBeat)
+            : null;
     }
 
     public bool ClaimOnStart(IBeat beat)
     {
-        throw new NotImplementedException();
+        for (var index = 0; index < _incativeList.Count; index++)
+        {
+            var rhythmInput = _incativeList[index];
+            if (rhythmInput.ClaimOnStart(beat))
+            {
+                _incativeList.Remove(rhythmInput);
+                _activeList.Add(rhythmInput);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void ReleaseInput()
     {
+        // todo: we might delete this because it's not even used???
         throw new NotImplementedException();
     }
 
     public InputSource GetSource()
     {
-        return _source;
+        return InputSource.Game;
     }
 
     public RhythmActionType GetRhythmActionType()
     {
-        return RhythmActionType.Invalid;
+        return RhythmActionType.Singular;
     }
 
     public void Activate()
     {
+        // exclusive on single input
         throw new NotImplementedException();
     }
 
     public void Release()
     {
+        // exclusive on single input
         throw new NotImplementedException();
+    }
+
+    public void AddInput(IRhythmInput realInput)
+    {
+        _incativeList.Add(realInput);
+    }
+
+    /// <summary>
+    /// Returns true when it's still going to accept inputs to handle
+    /// </summary>
+    /// <returns>bool</returns>
+    public bool IsStillAcceptingInputs()
+    {
+        return _simulator.GetCurrentSongTime() < _startingTime + VisualEpsilon;
     }
 }

--- a/Yam.Core/Rhythm/Input/MultiHoldInput.cs
+++ b/Yam.Core/Rhythm/Input/MultiHoldInput.cs
@@ -2,25 +2,27 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
-using Godot.NativeInterop;
 using Yam.Core.Common;
 using Yam.Core.Rhythm.Chart;
 
 namespace Yam.Core.Rhythm.Input;
 
-public class MultiHoldInput : IRhythmInput
+public class MultiHoldInput : IRhythmInput, IBeat
 {
+    public GameLogger Logger = new();
+
     public const float VisualEpsilon = 0.25f;
 
     private readonly IRhythmSimulator _simulator;
-    private readonly List<IRhythmInput> _incativeList = [];
+    private readonly List<IRhythmInput> _inactiveList = [];
     private readonly List<IRhythmInput> _activeList = [];
+    private readonly List<IBeat> _beatList = [];
     private readonly float _startingTime;
 
     public MultiHoldInput(IRhythmSimulator rhythmSimulator, IRhythmInput firstInput)
     {
         _simulator = rhythmSimulator;
-        _incativeList.Add(firstInput);
+        _inactiveList.Add(firstInput);
 
         _startingTime = _simulator.GetCurrentSongTime();
     }
@@ -48,26 +50,24 @@ public class MultiHoldInput : IRhythmInput
 
     public IBeat? GetClaimingChannel(IBeat contextualBeat)
     {
-        // todo: we need to make unit test here
-        if (_activeList.Exists(i => i.GetClaimingChannel(contextualBeat) == contextualBeat))
+        if (_beatList.Contains(contextualBeat))
         {
             return contextualBeat;
         }
 
-        return _activeList.Count > 0
-            ? _activeList[0].GetClaimingChannel(contextualBeat)
-            : null;
+        return null;
     }
 
     public bool ClaimOnStart(IBeat beat)
     {
-        for (var index = 0; index < _incativeList.Count; index++)
+        for (var index = 0; index < _inactiveList.Count; index++)
         {
-            var rhythmInput = _incativeList[index];
-            if (rhythmInput.ClaimOnStart(beat))
+            var rhythmInput = _inactiveList[index];
+            if (rhythmInput.ClaimOnStart(this))
             {
-                _incativeList.Remove(rhythmInput);
+                _inactiveList.Remove(rhythmInput);
                 _activeList.Add(rhythmInput);
+                _beatList.Add(beat);
                 return true;
             }
         }
@@ -103,9 +103,20 @@ public class MultiHoldInput : IRhythmInput
         throw new NotImplementedException();
     }
 
-    public void AddInput(IRhythmInput realInput)
+    public BeatInputResult? SimulateRelease()
     {
-        _incativeList.Add(realInput);
+        throw new NotImplementedException();
+    }
+
+    public bool AddInput(IRhythmInput realInput)
+    {
+        if (IsStillAcceptingInputs())
+        {
+            _inactiveList.Add(realInput);
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -115,5 +126,40 @@ public class MultiHoldInput : IRhythmInput
     public bool IsStillAcceptingInputs()
     {
         return _simulator.GetCurrentSongTime() < _startingTime + VisualEpsilon;
+    }
+
+    public void OnInputRelease()
+    {
+        if (!_beatList.Any())
+        {
+            Logger.PrintErr("Received onInputRelease event despite having no active inputs");
+            return;
+        }
+
+        var bestScore = BeatInputResultUtil.WorstScore;
+        var bestBeat = _beatList[0];
+
+        foreach (var beat in _beatList)
+        {
+            var currentScore = BeatInputResultUtil.GetScore(beat.OnSimulateInputRelease());
+            if (currentScore > bestScore)
+            {
+                bestScore = currentScore;
+                bestBeat = beat;
+            }
+        }
+
+        bestBeat.OnInputRelease();
+        _beatList.Remove(bestBeat);
+    }
+
+    public void SetVisualizer(IBeatVisualizer visualizer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public BeatInputResult OnSimulateInputRelease()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Yam.Core/Rhythm/Input/MultiHoldInput.cs
+++ b/Yam.Core/Rhythm/Input/MultiHoldInput.cs
@@ -1,0 +1,74 @@
+using System;
+using Godot;
+using Yam.Core.Rhythm.Chart;
+
+namespace Yam.Core.Rhythm.Input;
+
+public class MultiHoldInput : IRhythmInput
+{
+    // Inspired by the Null Object Pattern
+    public static readonly MultiHoldInput GameInput = new(InputSource.Game);
+    public static readonly MultiHoldInput UnknownInput = new(InputSource.Unknown);
+
+    private readonly InputSource _source;
+
+    private MultiHoldInput(InputSource source)
+    {
+        _source = source;
+    }
+
+    public bool IsValidDirection()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool IsDirectionSensitive()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Vector2 GetDirection()
+    {
+        throw new NotImplementedException();
+    }
+
+    public string GetInputCode()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IBeat? GetClaimingChannel()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool ClaimOnStart(IBeat beat)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ReleaseInput()
+    {
+        throw new NotImplementedException();
+    }
+
+    public InputSource GetSource()
+    {
+        return _source;
+    }
+
+    public RhythmActionType GetRhythmActionType()
+    {
+        return RhythmActionType.Invalid;
+    }
+
+    public void Activate()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Release()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Yam.Core/Rhythm/Input/MultiHoldInput.cs
+++ b/Yam.Core/Rhythm/Input/MultiHoldInput.cs
@@ -83,7 +83,7 @@ public class MultiHoldInput : IRhythmInput, IBeat
 
     public InputSource GetSource()
     {
-        return InputSource.Game;
+        return InputSource.Player;
     }
 
     public RhythmActionType GetRhythmActionType()

--- a/Yam.Core/Rhythm/Input/SpecialInput.cs
+++ b/Yam.Core/Rhythm/Input/SpecialInput.cs
@@ -37,7 +37,7 @@ public class SpecialInput : IRhythmInput
         throw new NotImplementedException();
     }
 
-    public IBeat? GetClaimingChannel()
+    public IBeat? GetClaimingChannel(IBeat contextualBeat)
     {
         throw new NotImplementedException();
     }

--- a/Yam.Game/Scenes/Rhythm/Charts/song-hold-test.rhythm.json
+++ b/Yam.Game/Scenes/Rhythm/Charts/song-hold-test.rhythm.json
@@ -1,0 +1,400 @@
+{
+	"BeatList": [
+		{
+			"BeatList": [
+				{
+					"Time": 4.654,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 5.563,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"BeatList": [
+				{
+					"Time": 4.654,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 5.163,
+					"UCoord": 128.0
+				}
+			]
+		},
+		{
+			"Time": 5.791,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 6.018,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 6.018,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 6.245,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 6.473,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 7.723,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 8.177,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 8.632,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 8.632,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 9.086,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 9.541,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 9.541,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 9.995,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 9.995,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 11.586,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 12.495,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 12.495,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 13.177,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 13.632,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 13.632,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 14.086,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 14.086,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 14.541,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 14.995,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 14.995,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 15.45,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 16.018,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 16.018,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 16.586,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 16.813,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 17.041,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 17.041,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 17.268,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 17.495,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 17.95,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 18.404,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 19.086,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 19.086,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 19.541,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 20.223,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 20.45,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 20.677,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 20.677,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 20.904,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 21.132,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 21.586,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 22.041,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 22.495,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 23.177,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 23.177,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 23.632,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 24.086,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 24.086,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 24.541,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 24.541,
+					"UCoord": 0.0
+				},
+				{
+					"Time": 25.45,
+					"UCoord": 0.0
+				}
+			]
+		},
+		{
+			"Time": 24.995,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 26.359,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 26.359,
+					"UCoord": 0.0,
+					"POut": {
+						"Time": 26.586,
+						"UCoord": 0.0
+					}
+				},
+				{
+					"Time": 26.813,
+					"UCoord": 128.0,
+					"PIn": {
+						"Time": 26.586,
+						"UCoord": 128.0
+					}
+				},
+				{
+					"Time": 27.268,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 27.723,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 28.177,
+					"UCoord": 128.0,
+					"POut": {
+						"Time": 28.4045,
+						"UCoord": 128.0
+					}
+				},
+				{
+					"Time": 28.632,
+					"UCoord": 0.0,
+					"PIn": {
+						"Time": 28.4045,
+						"UCoord": 0.0
+					}
+				}
+			]
+		},
+		{
+			"Time": 29.086,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 29.313,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 29.313,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 29.541,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 29.541,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 29.768,
+			"UCoord": 0.0
+		},
+		{
+			"Time": 29.768,
+			"UCoord": 256.0
+		},
+		{
+			"Time": 29.995,
+			"UCoord": 0.0,
+			"BeatList": [
+				{
+					"Time": 29.995,
+					"UCoord": 0.0,
+					"POut": {
+						"Time": 30.2225,
+						"UCoord": 0.0
+					}
+				},
+				{
+					"Time": 30.45,
+					"UCoord": 128.0,
+					"PIn": {
+						"Time": 30.2225,
+						"UCoord": 128.0
+					}
+				},
+				{
+					"Time": 30.904,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 31.132,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 31.586,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 31.813,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 32.041,
+					"UCoord": 128.0
+				},
+				{
+					"Time": 32.609,
+					"UCoord": 0.0
+				}
+			]
+		}
+	]
+}

--- a/Yam.Game/Scenes/Rhythm/Charts/song-test.rhythm.json
+++ b/Yam.Game/Scenes/Rhythm/Charts/song-test.rhythm.json
@@ -278,11 +278,19 @@
 	  "BeatList": [
 		{
 		  "Time": 26.359,
-		  "UCoord": 0
+		  "UCoord": 0,
+		  "POut": {
+			"Time": 26.586,
+			"UCoord": 0
+		  }
 		},
 		{
 		  "Time": 26.813,
-		  "UCoord": 128
+		  "UCoord": 128,
+		  "PIn": {
+			"Time": 26.586,
+			"UCoord": 128
+		  }
 		},
 		{
 		  "Time": 27.268,
@@ -294,11 +302,19 @@
 		},
 		{
 		  "Time": 28.177,
-		  "UCoord": 128
+		  "UCoord": 128,
+		  "POut": {
+			"Time": 28.4045,
+			"UCoord": 128
+		  }
 		},
 		{
 		  "Time": 28.632,
-		  "UCoord": 0
+		  "UCoord": 0,
+		  "PIn": {
+			"Time": 28.4045,
+			"UCoord": 0
+		  }
 		}
 	  ]
 	},
@@ -336,11 +352,19 @@
 	  "BeatList": [
 		{
 		  "Time": 29.995,
-		  "UCoord": 0
+		  "UCoord": 0,
+		  "POut": {
+			"Time": 30.2225,
+			"UCoord": 0
+		  }
 		},
 		{
 		  "Time": 30.45,
-		  "UCoord": 128
+		  "UCoord": 128,
+		  "PIn": {
+			"Time": 30.2225,
+			"UCoord": 128
+		  }
 		},
 		{
 		  "Time": 30.904,

--- a/Yam.Game/Scenes/Rhythm/RhythmPlayground/rhythm_playground.tscn
+++ b/Yam.Game/Scenes/Rhythm/RhythmPlayground/rhythm_playground.tscn
@@ -18,14 +18,14 @@ script = ExtResource("1_vddvi")
 [node name="RhythmPlayer" type="Node" parent="." node_paths=PackedStringArray("AudioStreamPlayer", "TriggerPoint", "SpawnPoint", "DestructionPoint", "Parent")]
 script = ExtResource("2_hdbk4")
 Chart = ExtResource("3_2dqin")
-AudioStream = ExtResource("4_kql7o")
-SingleBeatPrefab = ExtResource("5_711h0")
-TickPrefab = ExtResource("6_n4de7")
-PreEmptDuration = 1.5
 AudioStreamPlayer = NodePath("../AudioStreamPlayer")
+AudioStream = ExtResource("4_kql7o")
 TriggerPoint = NodePath("../Trigger point")
 SpawnPoint = NodePath("../Spawn point")
 DestructionPoint = NodePath("../Destruction point")
+SingleBeatPrefab = ExtResource("5_711h0")
+TickPrefab = ExtResource("6_n4de7")
+PreEmptDuration = 1.5
 Parent = NodePath("..")
 
 [node name="Trigger point" type="Sprite2D" parent="."]

--- a/Yam.Game/Scenes/Rhythm/RhythmPlayground/rhythm_playground_hold.tscn
+++ b/Yam.Game/Scenes/Rhythm/RhythmPlayground/rhythm_playground_hold.tscn
@@ -1,0 +1,57 @@
+[gd_scene load_steps=10 format=3 uid="uid://666i5uf4g355"]
+
+[ext_resource type="Script" uid="uid://bur6k5g353rhb" path="res://Scripts/Rhythm/Dev/ParseOsu.cs" id="1_oac8v"]
+[ext_resource type="Script" uid="uid://bbr4yobycov78" path="res://Scripts/Rhythm/RhythmSimulator.cs" id="2_mylgg"]
+[ext_resource type="JSON" path="res://Scenes/Rhythm/Charts/song-hold-test.rhythm.json" id="3_oac8v"]
+[ext_resource type="AudioStream" uid="uid://bjopcy3y4o24c" path="res://Scenes/Rhythm/Songs/sunleth_waterscape/Final Fantasy XIII - The Sunleth Waterscape.mp3" id="4_5dqyy"]
+[ext_resource type="PackedScene" uid="uid://cwlyq1np8ldmr" path="res://Scenes/Rhythm/RhythmPlayground/single_beat.tscn" id="5_x31qe"]
+[ext_resource type="PackedScene" uid="uid://bh1kbt58r72bx" path="res://Scenes/Rhythm/RhythmPlayground/tick.tscn" id="6_7lxg4"]
+[ext_resource type="Texture2D" uid="uid://corpi772is0cb" path="res://Assets/Placeholder/white_square.png" id="7_6hqd1"]
+[ext_resource type="PackedScene" uid="uid://b4qgmtd1nn3m6" path="res://Scenes/Rhythm/RhythmPlayground/hold_line.tscn" id="8_a6ujk"]
+[ext_resource type="Script" uid="uid://bi1sdmd8agfnw" path="res://Scripts/Rhythm/Dev/TestDrawing.cs" id="9_kj4qu"]
+
+[node name="RhythmEditor" type="Node2D"]
+
+[node name="ParseOsu" type="Node" parent="."]
+script = ExtResource("1_oac8v")
+
+[node name="RhythmPlayer" type="Node" parent="." node_paths=PackedStringArray("AudioStreamPlayer", "TriggerPoint", "SpawnPoint", "DestructionPoint", "Parent")]
+script = ExtResource("2_mylgg")
+Chart = ExtResource("3_oac8v")
+AudioStreamPlayer = NodePath("../AudioStreamPlayer")
+AudioStream = ExtResource("4_5dqyy")
+TriggerPoint = NodePath("../Trigger point")
+SpawnPoint = NodePath("../Spawn point")
+DestructionPoint = NodePath("../Destruction point")
+SingleBeatPrefab = ExtResource("5_x31qe")
+TickPrefab = ExtResource("6_7lxg4")
+PreEmptDuration = 1.5
+Parent = NodePath("..")
+
+[node name="Trigger point" type="Sprite2D" parent="."]
+position = Vector2(614, 84)
+texture = ExtResource("7_6hqd1")
+
+[node name="Spawn point" type="Sprite2D" parent="."]
+position = Vector2(-130, 84)
+texture = ExtResource("7_6hqd1")
+
+[node name="Destruction point" type="Sprite2D" parent="."]
+position = Vector2(1100, 84)
+texture = ExtResource("7_6hqd1")
+
+[node name="single_beat" parent="." instance=ExtResource("5_x31qe")]
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+
+[node name="hold_line" parent="." instance=ExtResource("8_a6ujk")]
+
+[node name="test_drawing" type="Node2D" parent="."]
+visible = false
+position = Vector2(150, 121)
+script = ExtResource("9_kj4qu")
+P1In = Vector2(200, 0)
+P2 = Vector2(400, 400)
+P2Out = Vector2(200, 400)
+DivisionMultiplier = 0.1
+IsOn = false

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
@@ -61,6 +61,11 @@ public partial class HoldBeat : Node2D, IBasicListener, IBeatVisualizer
 
         Position = Position with { X = x };
 
+        if (_mainBeat.GetState() == Beat.State.Holding)
+        {
+            _mainBeat.SimulateHoldingIdleBeat();
+        }
+
         // todo: kill when endBeat reaches beyond
     }
 

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldBeat.cs
@@ -10,6 +10,7 @@ public partial class HoldBeat : Node2D, IBasicListener, IBeatVisualizer
 {
     private Beat _mainBeat;
     private RhythmSimulator _rhythmSimulator;
+
     /** HoldBeat handles instantiating _endBeat */
     private SingleBeat.SingleBeat _endSingleBeat;
 
@@ -43,7 +44,6 @@ public partial class HoldBeat : Node2D, IBasicListener, IBeatVisualizer
         }
 
         _isActive = true;
-
     }
 
     public override void _Process(double delta)

--- a/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
+++ b/Yam.Game/Scripts/Rhythm/Game/HoldBeat/HoldPiece.cs
@@ -63,7 +63,7 @@ public partial class HoldPiece : Node2D
         _increment = 1f / _divisions;
 
         Position = new Vector2(_ogP1.X - SingleBeat.SingleBeat.TimeToX(rhythmSimulator, parentBeat.Time),
-            startBeat.UCoord);
+            startBeat.UCoord - parentBeat.UCoord);
     }
 
 

--- a/Yam.Game/Scripts/Rhythm/RhythmSimulator.cs
+++ b/Yam.Game/Scripts/Rhythm/RhythmSimulator.cs
@@ -183,6 +183,7 @@ public partial class RhythmSimulator : Node, IRhythmSimulator
 
     public override void _UnhandledInput(InputEvent @event)
     {
+        // todo(turnip): prioritize simulating a slide direction
         _chartModel.SimulateBeatInput(this, _inputProvider.ProcessEvent(@event));
     }
 }


### PR DESCRIPTION
## What's this change for?

Enable game to give players the best score or scenario when prompted multiple hold inputs.

## Detailed description

There are cases when there are multiple inputs, and they may have different release requirements. Players may not know which input is associated with an input, so we will choose the best case during the time they release an input.

**Other changes:**

- Improve GameLogger
- Fix several beat logic implementation and tests
- Update pull request
- Fix hold beat visualization when the initial hold beat ucoord is not equal to zero

## Testing
- [x] Insert manual, unit, and automated tests here

## Documentation
- [x] Add specific documentations and link their files (in the current branch not main)
- Insert related info and documentation here

## References
*We're using pull requests as a way to also document. So, put all the references and resources used to help make the changes in each PRs*

- [x] Add a log for this PR and link their files (in the current branch not main)
- [x] Insert how you solved the problem
- [x] Insert all references and help used to solve this problem

## TODO

| Task |  Description | Date added | Date started | Date finished |
|---|---|---|---|---|
| Second input |  Investigate how to ingest second input into the input wrapper | 25-01-21 | 25-01-25 | 25-01-25 |
| Simulate game |  Investigate how to simulate a game update on the beats handled within the input wrapper | 25-01-21 | 25-01-25 | 25-01-25 |
| Simulate late release | - | 25-01-21 | 25-01-26 | 25-01-26 |
| Simulate excellent release | - | 25-01-21 | 25-01-26 | 25-01-26 |

## Updates

- **25-01-25:** We can fake the MultiHoldInput as an input. Now we'll make tests for and implement how a player input release or game idle simulate would work. Note that this wrapper will try to decide the best signals to send to the beat. Hope this makes sense to future me reading this.
- **25-01-25 (again):** We finished it lol. Another way to probably solve this better is by refactoring our Beat-Input interaction into Resource (Input) - Middleman - Evaluator (Beat). Our current setup is that Beat also decide the final rule. By having a middleman, the middleman decides the best situation between the evaluators and resources. It kinda is like that already with the Beat/Input wrapper, the MultiBeatInput. MultiBeatInput collects the inputs and beats, and simulates beats according to the latest inputs it receives. The advantage I can think of with the current design is that we can focus on putting the evaluations on the Beat layer, instead of having it split between the Chart simulation and the Beat evaulators. Although, our chart simulation code is so smelly, and the unit test associated with it is unwieldy.